### PR TITLE
feat: deepen compare proof lanes

### DIFF
--- a/frontend/src/components/AppShell.tsx
+++ b/frontend/src/components/AppShell.tsx
@@ -8,8 +8,76 @@ function navClass(isActive: boolean): string {
     : "btn btn-sm btn-ghost text-ink";
 }
 
+function contextNavClass(isActive: boolean): string {
+  return isActive
+    ? "btn btn-xs border-ink bg-base-200 text-ink"
+    : "btn btn-xs btn-ghost text-slate-600";
+}
+
+function buildShellFocus(route: string, locale: string): {
+  label: string;
+  headline: string;
+  summary: string;
+  proofPath: string;
+} {
+  const zh = locale === "zh-CN";
+
+  if (route === "watch-new") {
+    return {
+      label: zh ? "当前重点" : "Current focus",
+      headline: zh ? "把已确认的一行变成可执行 watch state" : "Turn one confirmed row into executable watch state",
+      summary: zh
+        ? "这里只有在 compare 结果已经站住脚之后才值得继续。先把标题、候选键和提醒人填对，再提交。"
+        : "This lane only matters after the compare result is honest enough. Confirm the title, candidate key, and recipient before you commit.",
+      proofPath: zh
+        ? "证据路径：先保留 compare 包，再把单行 watch task 当成最后一步。"
+        : "Proof path: keep the compare package first, then treat the one-row watch task as the final move.",
+    };
+  }
+
+  if (route === "watch-list") {
+    return {
+      label: zh ? "当前重点" : "Current focus",
+      headline: zh ? "先看哪些 watch 还需要人确认，不要直接继续加新 URL" : "Review which watches still need confirmation before adding more URLs",
+      summary: zh
+        ? "如果已有 watch 或 group 在排队，就先回到它们的证据和冷却状态，再决定是否重新 compare。"
+        : "If watches or groups are already queued, return to their evidence and cooldown state before starting another compare run.",
+      proofPath: zh
+        ? "证据路径：watch list 只吃已经站稳的 compare 结果，不替代 compare 本身。"
+        : "Proof path: the watch list only consumes compare results that already stand on solid evidence; it does not replace compare itself.",
+    };
+  }
+
+  if (route === "settings") {
+    return {
+      label: zh ? "当前重点" : "Current focus",
+      headline: zh ? "把提醒节奏调成可信执行面" : "Tune the reminder cadence into a trustworthy execution surface",
+      summary: zh
+        ? "这里不是主入口，但它决定后面的提醒有没有噪音。先确认收件人和冷却时间，再回 compare。"
+        : "This is not the primary lane, but it decides whether later alerts become noise. Confirm the recipient and cooldown before you go back to compare.",
+      proofPath: zh
+        ? "证据路径：设置页负责守纪律，不负责制造结论。"
+        : "Proof path: settings enforce discipline; they do not create the decision itself.",
+    };
+  }
+
+  return {
+    label: zh ? "当前重点" : "Current focus",
+    headline: zh ? "先把 basket 比干净，再决定是否进入 watch state" : "Cleanly compare the basket before moving anything into watch state",
+    summary: zh
+      ? "先比较至少两条商品 URL，让 decision board 说清楚谁更强、哪里还不稳，再决定是建 group 还是只保留证据。"
+      : "Compare at least two product URLs first, let the decision board explain what is strong and what is still shaky, then decide between a watch group or evidence-only review.",
+    proofPath: zh
+      ? "证据路径：先保存本地 evidence package；只有在 basket 足够诚实时，才继续创建 runtime package 或 watch group。"
+      : "Proof path: save a local evidence package first; only move into runtime packages or watch groups once the basket is honest enough.",
+  };
+}
+
 export function AppShell(props: { children: ComponentChildren }) {
   const { locale, setLocale, t } = useI18n();
+  const hasContextActions =
+    currentRoute.value === "watch-new" || Boolean(currentTaskId.value) || Boolean(currentGroupId.value);
+  const shellFocus = buildShellFocus(currentRoute.value, locale);
 
   return (
     <div class="min-h-screen bg-mesh grid-fade text-ink">
@@ -56,52 +124,109 @@ export function AppShell(props: { children: ComponentChildren }) {
             </div>
           </div>
 
-          <nav class="mt-5 flex flex-wrap gap-2">
-            <button
-              class={navClass(currentRoute.value === "compare")}
-              onClick={() => navigate("compare")}
-              type="button"
-            >
-              {t("shell.nav.compare")}
-            </button>
-            <button
-              class={navClass(currentRoute.value === "watch-list")}
-              onClick={() => navigate("watch-list")}
-              type="button"
-            >
-              {t("shell.nav.watchList")}
-            </button>
-            <button
-              class={navClass(currentRoute.value === "watch-new")}
-              onClick={() => navigate("watch-new")}
-              type="button"
-            >
-              {t("shell.nav.watchNew")}
-            </button>
-            <button
-              class={navClass(currentRoute.value === "watch-detail")}
-              disabled={!currentTaskId.value}
-              onClick={() => navigate("watch-detail")}
-              type="button"
-            >
-              {t("shell.nav.watchDetail")}
-            </button>
-            <button
-              class={navClass(currentRoute.value === "watch-group-detail")}
-              disabled={!currentGroupId.value}
-              onClick={() => navigate("watch-group-detail")}
-              type="button"
-            >
-              {t("shell.nav.watchGroupDetail")}
-            </button>
-            <button
-              class={navClass(currentRoute.value === "settings")}
-              onClick={() => navigate("settings")}
-              type="button"
-            >
-              {t("shell.nav.settings")}
-            </button>
-          </nav>
+          <div class="mt-5 border-t border-base-300/70 pt-4">
+            <div class="flex flex-wrap items-center gap-2">
+              <span class="text-[11px] font-semibold uppercase tracking-[0.16em] text-slate-500">
+                {t("shell.primaryPathLabel")}
+              </span>
+              <span class="badge badge-outline border-ember/30 bg-base-200/70 text-ember">
+                1. {t("shell.primaryPathCompare")}
+              </span>
+              <span class="text-slate-400">-&gt;</span>
+              <span class="badge badge-outline border-ink/15 bg-base-200/70 text-ink">
+                2. {t("shell.primaryPathDecision")}
+              </span>
+              <span class="text-slate-400">-&gt;</span>
+              <span class="badge badge-outline border-ink/15 bg-base-200/70 text-ink">
+                3. {t("shell.primaryPathCommit")}
+              </span>
+            </div>
+
+            <div class="mt-4 flex flex-col gap-3 xl:flex-row xl:items-center xl:justify-between">
+              <div class="flex flex-col gap-2">
+                <span class="text-[11px] font-semibold uppercase tracking-[0.16em] text-slate-500">
+                  {t("shell.primaryNavLabel")}
+                </span>
+                <nav class="flex flex-wrap gap-2">
+                  <button
+                    class={navClass(currentRoute.value === "compare")}
+                    onClick={() => navigate("compare")}
+                    type="button"
+                  >
+                    {t("shell.nav.compare")}
+                  </button>
+                  <button
+                    class={navClass(currentRoute.value === "watch-list")}
+                    onClick={() => navigate("watch-list")}
+                    type="button"
+                  >
+                    {t("shell.nav.watchList")}
+                  </button>
+                  <button
+                    class={navClass(currentRoute.value === "settings")}
+                    onClick={() => navigate("settings")}
+                    type="button"
+                  >
+                    {t("shell.nav.settings")}
+                  </button>
+                </nav>
+              </div>
+
+              <div class="flex flex-col gap-2 xl:items-end">
+                <span class="text-[11px] font-semibold uppercase tracking-[0.16em] text-slate-500">
+                  {t("shell.secondaryNavLabel")}
+                </span>
+                <div class="flex flex-wrap items-center gap-2">
+                  {currentRoute.value === "watch-new" ? (
+                    <button
+                      class={contextNavClass(true)}
+                      onClick={() => navigate("watch-new")}
+                      type="button"
+                    >
+                      {t("shell.nav.watchNew")}
+                    </button>
+                  ) : null}
+                  {currentTaskId.value ? (
+                    <button
+                      class={contextNavClass(currentRoute.value === "watch-detail")}
+                      onClick={() => navigate("watch-detail")}
+                      type="button"
+                    >
+                      {t("shell.nav.watchDetail")}
+                    </button>
+                  ) : null}
+                  {currentGroupId.value ? (
+                    <button
+                      class={contextNavClass(currentRoute.value === "watch-group-detail")}
+                      onClick={() => navigate("watch-group-detail")}
+                      type="button"
+                    >
+                      {t("shell.nav.watchGroupDetail")}
+                    </button>
+                  ) : null}
+                  {!hasContextActions ? (
+                    <span class="text-xs text-slate-500">{t("shell.secondaryHint")}</span>
+                  ) : null}
+                </div>
+              </div>
+            </div>
+
+            <div class="mt-4 grid gap-3 xl:grid-cols-[1.3fr,0.7fr]">
+              <div class="rounded-[1.5rem] border border-ink/10 bg-gradient-to-r from-base-100 via-base-100 to-base-200/70 px-4 py-4 shadow-sm">
+                <div class="text-[11px] font-semibold uppercase tracking-[0.16em] text-slate-500">
+                  {shellFocus.label}
+                </div>
+                <div class="mt-2 text-lg font-semibold text-ink">{shellFocus.headline}</div>
+                <p class="mt-2 text-sm leading-6 text-slate-600">{shellFocus.summary}</p>
+              </div>
+              <div class="rounded-[1.5rem] border border-ember/20 bg-ember/5 px-4 py-4">
+                <div class="text-[11px] font-semibold uppercase tracking-[0.16em] text-ember">
+                  {locale === "zh-CN" ? "证据路径" : "Proof path"}
+                </div>
+                <p class="mt-2 text-sm leading-6 text-slate-700">{shellFocus.proofPath}</p>
+              </div>
+            </div>
+          </div>
         </header>
 
         <main class="flex-1">{props.children}</main>

--- a/frontend/src/components/AppShell.tsx
+++ b/frontend/src/components/AppShell.tsx
@@ -14,62 +14,52 @@ function contextNavClass(isActive: boolean): string {
     : "btn btn-xs btn-ghost text-slate-600";
 }
 
-function buildShellFocus(route: string, locale: string): {
+function buildShellFocus(route: string, t: (key: string) => string): {
   label: string;
   headline: string;
   summary: string;
   proofPath: string;
 } {
-  const zh = locale === "zh-CN";
-
+  const baseKey =
+    route === "watch-new"
+      ? "shell.focus.watchNew"
+      : route === "watch-list"
+        ? "shell.focus.watchList"
+        : route === "settings"
+          ? "shell.focus.settings"
+          : "shell.focus.compare";
   if (route === "watch-new") {
     return {
-      label: zh ? "当前重点" : "Current focus",
-      headline: zh ? "把已确认的一行变成可执行 watch state" : "Turn one confirmed row into executable watch state",
-      summary: zh
-        ? "这里只有在 compare 结果已经站住脚之后才值得继续。先把标题、候选键和提醒人填对，再提交。"
-        : "This lane only matters after the compare result is honest enough. Confirm the title, candidate key, and recipient before you commit.",
-      proofPath: zh
-        ? "证据路径：先保留 compare 包，再把单行 watch task 当成最后一步。"
-        : "Proof path: keep the compare package first, then treat the one-row watch task as the final move.",
+      label: t(`${baseKey}.label`),
+      headline: t(`${baseKey}.headline`),
+      summary: t(`${baseKey}.summary`),
+      proofPath: t(`${baseKey}.proofPath`),
     };
   }
 
   if (route === "watch-list") {
     return {
-      label: zh ? "当前重点" : "Current focus",
-      headline: zh ? "先看哪些 watch 还需要人确认，不要直接继续加新 URL" : "Review which watches still need confirmation before adding more URLs",
-      summary: zh
-        ? "如果已有 watch 或 group 在排队，就先回到它们的证据和冷却状态，再决定是否重新 compare。"
-        : "If watches or groups are already queued, return to their evidence and cooldown state before starting another compare run.",
-      proofPath: zh
-        ? "证据路径：watch list 只吃已经站稳的 compare 结果，不替代 compare 本身。"
-        : "Proof path: the watch list only consumes compare results that already stand on solid evidence; it does not replace compare itself.",
+      label: t(`${baseKey}.label`),
+      headline: t(`${baseKey}.headline`),
+      summary: t(`${baseKey}.summary`),
+      proofPath: t(`${baseKey}.proofPath`),
     };
   }
 
   if (route === "settings") {
     return {
-      label: zh ? "当前重点" : "Current focus",
-      headline: zh ? "把提醒节奏调成可信执行面" : "Tune the reminder cadence into a trustworthy execution surface",
-      summary: zh
-        ? "这里不是主入口，但它决定后面的提醒有没有噪音。先确认收件人和冷却时间，再回 compare。"
-        : "This is not the primary lane, but it decides whether later alerts become noise. Confirm the recipient and cooldown before you go back to compare.",
-      proofPath: zh
-        ? "证据路径：设置页负责守纪律，不负责制造结论。"
-        : "Proof path: settings enforce discipline; they do not create the decision itself.",
+      label: t(`${baseKey}.label`),
+      headline: t(`${baseKey}.headline`),
+      summary: t(`${baseKey}.summary`),
+      proofPath: t(`${baseKey}.proofPath`),
     };
   }
 
   return {
-    label: zh ? "当前重点" : "Current focus",
-    headline: zh ? "先把 basket 比干净，再决定是否进入 watch state" : "Cleanly compare the basket before moving anything into watch state",
-    summary: zh
-      ? "先比较至少两条商品 URL，让 decision board 说清楚谁更强、哪里还不稳，再决定是建 group 还是只保留证据。"
-      : "Compare at least two product URLs first, let the decision board explain what is strong and what is still shaky, then decide between a watch group or evidence-only review.",
-    proofPath: zh
-      ? "证据路径：先保存本地 evidence package；只有在 basket 足够诚实时，才继续创建 runtime package 或 watch group。"
-      : "Proof path: save a local evidence package first; only move into runtime packages or watch groups once the basket is honest enough.",
+    label: t(`${baseKey}.label`),
+    headline: t(`${baseKey}.headline`),
+    summary: t(`${baseKey}.summary`),
+    proofPath: t(`${baseKey}.proofPath`),
   };
 }
 
@@ -77,7 +67,7 @@ export function AppShell(props: { children: ComponentChildren }) {
   const { locale, setLocale, t } = useI18n();
   const hasContextActions =
     currentRoute.value === "watch-new" || Boolean(currentTaskId.value) || Boolean(currentGroupId.value);
-  const shellFocus = buildShellFocus(currentRoute.value, locale);
+  const shellFocus = buildShellFocus(currentRoute.value, t);
 
   return (
     <div class="min-h-screen bg-mesh grid-fade text-ink">
@@ -221,7 +211,7 @@ export function AppShell(props: { children: ComponentChildren }) {
               </div>
               <div class="rounded-[1.5rem] border border-ember/20 bg-ember/5 px-4 py-4">
                 <div class="text-[11px] font-semibold uppercase tracking-[0.16em] text-ember">
-                  {locale === "zh-CN" ? "证据路径" : "Proof path"}
+                  {t("shell.focus.proofLabel")}
                 </div>
                 <p class="mt-2 text-sm leading-6 text-slate-700">{shellFocus.proofPath}</p>
               </div>

--- a/frontend/src/pages/ComparePage.tsx
+++ b/frontend/src/pages/ComparePage.tsx
@@ -43,6 +43,76 @@ import {
   type CompareGroupFormState,
 } from "./compare/sections";
 
+function compareExecutionCopy(
+  locale: string,
+  values: {
+    hasDecision: boolean;
+    hasSavedPackage: boolean;
+    hasRuntimePackage: boolean;
+    groupReadyCount: number;
+  },
+): {
+  laneTitle: string;
+  laneSummary: string;
+  proofTitle: string;
+  proofSummary: string;
+  commitTitle: string;
+  commitSummary: string;
+  saveLabel: string;
+  runtimeLabel: string;
+  jumpLabel: string;
+} {
+  if (locale === "zh-CN") {
+    return {
+      laneTitle: values.hasDecision ? "下一步：按 decision board 行动" : "下一步：先跑出 compare 结果",
+      laneSummary: values.hasDecision
+        ? "别直接跳去建 watch。先看 decision board 推荐的是继续 review、建 group，还是只保留证据。"
+        : "先提交至少两条 URL，让 compare 结果把 basket 里最强的一行和最该警惕的风险说清楚。",
+      proofTitle: values.hasRuntimePackage
+        ? "证据已进入 runtime 包"
+        : values.hasSavedPackage
+          ? "证据已本地保存，仍可继续加固"
+          : "证据还没落袋",
+      proofSummary: values.hasRuntimePackage
+        ? "这轮 compare 已经有 runtime-backed proof，可以带着清楚的边界继续往下走。"
+        : values.hasSavedPackage
+          ? "本地 evidence package 已保存。下一步只有在这篮子还站得住时，才值得继续铸成 runtime 包。"
+          : "先把 evidence package 存下来，再谈 commit。这样你回头复核时不会只剩一张好看的页面。",
+      commitTitle: values.groupReadyCount >= 2 ? "可以考虑进入 compare-aware watch group" : "还不到 commit 成 group 的时机",
+      commitSummary: values.groupReadyCount >= 2
+        ? `当前已有 ${values.groupReadyCount} 个 group-ready 行，可以进入 watch group builder，但前提还是证据先站稳。`
+        : "现在更像 review lane，不像 commit lane。先把支持度不足的行留在证据层，不要急着变成长期 watch state。",
+      saveLabel: "先保存本地证据",
+      runtimeLabel: "再铸成 runtime 包",
+      jumpLabel: "查看 commit 入口",
+    };
+  }
+
+  return {
+    laneTitle: values.hasDecision ? "Next move: follow the decision board" : "Next move: generate a clean compare result",
+    laneSummary: values.hasDecision
+      ? "Do not jump straight into watch creation. Use the decision board to decide whether this basket should stay in review, become a group, or stop at evidence."
+      : "Submit at least two URLs first so the compare run can name the strongest row and the sharpest risk inside the basket.",
+    proofTitle: values.hasRuntimePackage
+      ? "Proof already has a runtime-backed package"
+      : values.hasSavedPackage
+        ? "Proof is saved locally and still reviewable"
+        : "Proof is not stored yet",
+    proofSummary: values.hasRuntimePackage
+      ? "This compare run already has a runtime-backed proof package, so the next move can stay honest without pretending the basket is final."
+      : values.hasSavedPackage
+        ? "A local evidence package exists. Promote it only if the basket still stands up after review."
+        : "Save the evidence package before you commit anything. That way the proof survives even if the basket needs one more review pass.",
+    commitTitle: values.groupReadyCount >= 2 ? "This basket can move toward a compare-aware watch group" : "This basket is not ready to commit into a group yet",
+    commitSummary: values.groupReadyCount >= 2
+      ? `${values.groupReadyCount} rows are group-ready, so the group builder can become the final lane after the proof is preserved.`
+      : "This still behaves like a review lane, not a commit lane. Keep weaker rows in evidence instead of freezing them into long-lived watch state.",
+    saveLabel: "Save local proof first",
+    runtimeLabel: "Then mint runtime proof",
+    jumpLabel: "Open commit lane",
+  };
+}
+
 function readComparePrefillFromUrl(): { rawUrls: string; used: boolean } {
   if (typeof window === "undefined") {
     return { rawUrls: defaultUrls, used: false };
@@ -221,6 +291,18 @@ export function ComparePage() {
     () => savedPackages.find((item) => item.id === selectedPackageId) ?? savedPackages[0] ?? null,
     [savedPackages, selectedPackageId],
   );
+  const currentRuntimePackage = useMemo(() => {
+    if (!draftPackageId) {
+      return null;
+    }
+    return savedPackages.find((item) => item.id === draftPackageId)?.runtimeArtifact ?? null;
+  }, [draftPackageId, savedPackages]);
+  const executionRail = compareExecutionCopy(locale, {
+    hasDecision: Boolean(decisionBoard),
+    hasSavedPackage: savedPackages.length > 0 || Boolean(draftPackageId),
+    hasRuntimePackage: Boolean(currentRuntimePackage),
+    groupReadyCount: groupReadyCandidates.length,
+  });
 
   useEffect(() => {
     if (!groupReadyCandidates.length) {
@@ -409,46 +491,117 @@ export function ComparePage() {
 
   return (
     <section class="space-y-4">
-      <form
-        class="rounded-[1.75rem] border border-base-300 bg-base-100/95 p-6 shadow-card"
-        onSubmit={onSubmit}
-      >
-        <p class="text-xs font-semibold uppercase tracking-[0.2em] text-ember">{t("compare.form.eyebrow")}</p>
-        <h2 class="mt-2 text-2xl font-semibold text-ink">
-          {t("compare.form.title")}
-        </h2>
-        <p class="mt-2 text-sm leading-6 text-slate-600">
-          {t("compare.form.summary")}
-        </p>
+      <div class="grid gap-4 xl:grid-cols-[1.05fr,0.95fr]">
+        <div class="rounded-[1.75rem] border border-base-300 bg-base-100/95 p-6 shadow-card">
+          <p class="text-xs font-semibold uppercase tracking-[0.2em] text-ember">{t("compare.route.eyebrow")}</p>
+          <h2 class="mt-2 text-2xl font-semibold text-ink">{t("compare.route.title")}</h2>
+          <p class="mt-2 text-sm leading-6 text-slate-600">{t("compare.route.summary")}</p>
 
-        <div class="mt-6 grid gap-4">
-          <label class="form-control gap-2">
-            <span class="label-text block font-medium">{t("compare.form.zipCode")}</span>
-            <input
-              class="input input-bordered"
-              onInput={(event) => setZipCode((event.currentTarget as HTMLInputElement).value)}
-              value={zipCode}
-            />
-          </label>
-
-          <label class="form-control gap-2">
-            <span class="label-text block font-medium">{t("compare.form.productUrls")}</span>
-            <textarea
-              class="textarea textarea-bordered min-h-48"
-              onInput={(event) => setRawUrls((event.currentTarget as HTMLTextAreaElement).value)}
-              value={rawUrls}
-            />
-            <span class="label-text-alt mt-2 text-slate-500">{t("compare.form.productUrlsHelp")}</span>
-          </label>
+          <div class="mt-5 grid gap-3 md:grid-cols-3">
+            <div class="rounded-2xl border border-base-300 bg-base-200/50 px-4 py-4">
+              <div class="text-[11px] font-semibold uppercase tracking-[0.16em] text-slate-500">1</div>
+              <div class="mt-2 text-base font-semibold text-ink">{t("compare.route.stepCompareTitle")}</div>
+              <p class="mt-2 text-sm leading-6 text-slate-600">{t("compare.route.stepCompareSummary")}</p>
+            </div>
+            <div class="rounded-2xl border border-base-300 bg-base-200/50 px-4 py-4">
+              <div class="text-[11px] font-semibold uppercase tracking-[0.16em] text-slate-500">2</div>
+              <div class="mt-2 text-base font-semibold text-ink">{t("compare.route.stepDecisionTitle")}</div>
+              <p class="mt-2 text-sm leading-6 text-slate-600">{t("compare.route.stepDecisionSummary")}</p>
+            </div>
+            <div class="rounded-2xl border border-base-300 bg-base-200/50 px-4 py-4">
+              <div class="text-[11px] font-semibold uppercase tracking-[0.16em] text-slate-500">3</div>
+              <div class="mt-2 text-base font-semibold text-ink">{t("compare.route.stepCommitTitle")}</div>
+              <p class="mt-2 text-sm leading-6 text-slate-600">{t("compare.route.stepCommitSummary")}</p>
+            </div>
+          </div>
         </div>
 
-        {error ? <div class="alert alert-error mt-5">{resolveUiMessage(error, t)}</div> : null}
-        {mutation.isPending ? <div class="alert alert-info mt-5">{t("compare.form.loading")}</div> : null}
+        <div class="rounded-[1.75rem] border border-base-300 bg-base-100/95 p-6 shadow-card">
+          <p class="text-xs font-semibold uppercase tracking-[0.2em] text-ember">{t("compare.form.eyebrow")}</p>
+          <h2 class="mt-2 text-2xl font-semibold text-ink">
+            {t("compare.form.title")}
+          </h2>
+          <p class="mt-2 text-sm leading-6 text-slate-600">
+            {t("compare.form.summary")}
+          </p>
 
-        <div class="mt-6">
-          <button class="btn btn-primary" type="submit">{t("compare.form.submit")}</button>
+          <form class="mt-6 grid gap-4" onSubmit={onSubmit}>
+            <label class="form-control gap-2">
+              <span class="label-text block font-medium">{t("compare.form.zipCode")}</span>
+              <input
+                class="input input-bordered"
+                onInput={(event) => setZipCode((event.currentTarget as HTMLInputElement).value)}
+                value={zipCode}
+              />
+            </label>
+
+            <label class="form-control gap-2">
+              <span class="label-text block font-medium">{t("compare.form.productUrls")}</span>
+              <textarea
+                class="textarea textarea-bordered min-h-48"
+                onInput={(event) => setRawUrls((event.currentTarget as HTMLTextAreaElement).value)}
+                value={rawUrls}
+              />
+              <span class="label-text-alt mt-2 text-slate-500">{t("compare.form.productUrlsHelp")}</span>
+            </label>
+
+            {error ? <div class="alert alert-error">{resolveUiMessage(error, t)}</div> : null}
+            {mutation.isPending ? <div class="alert alert-info">{t("compare.form.loading")}</div> : null}
+
+            <div class="pt-2">
+              <button class="btn btn-primary" type="submit">{t("compare.form.submit")}</button>
+            </div>
+          </form>
         </div>
-      </form>
+      </div>
+
+      <div class="grid gap-4 xl:grid-cols-[1.1fr,0.9fr,0.9fr]">
+        <div class="rounded-[1.5rem] border border-ink/10 bg-base-100/95 p-5 shadow-card">
+          <p class="text-[11px] font-semibold uppercase tracking-[0.16em] text-slate-500">
+            {locale === "zh-CN" ? "执行路线" : "Execution lane"}
+          </p>
+          <h3 class="mt-2 text-lg font-semibold text-ink">{executionRail.laneTitle}</h3>
+          <p class="mt-2 text-sm leading-6 text-slate-600">{executionRail.laneSummary}</p>
+        </div>
+
+        <div class="rounded-[1.5rem] border border-ember/20 bg-ember/5 p-5 shadow-card">
+          <p class="text-[11px] font-semibold uppercase tracking-[0.16em] text-ember">
+            {locale === "zh-CN" ? "证明路线" : "Proof lane"}
+          </p>
+          <h3 class="mt-2 text-lg font-semibold text-ink">{executionRail.proofTitle}</h3>
+          <p class="mt-2 text-sm leading-6 text-slate-700">{executionRail.proofSummary}</p>
+          {result ? (
+            <div class="mt-4 flex flex-wrap gap-2">
+              <button class="btn btn-outline btn-sm" onClick={handleSaveEvidencePackage} type="button">
+                {executionRail.saveLabel}
+              </button>
+              <button
+                class="btn btn-primary btn-sm"
+                disabled={createEvidencePackageMutation.isPending}
+                onClick={handleCreateRuntimeEvidencePackage}
+                type="button"
+              >
+                {executionRail.runtimeLabel}
+              </button>
+            </div>
+          ) : null}
+        </div>
+
+        <div class="rounded-[1.5rem] border border-base-300 bg-base-100/95 p-5 shadow-card">
+          <p class="text-[11px] font-semibold uppercase tracking-[0.16em] text-slate-500">
+            {locale === "zh-CN" ? "提交路线" : "Commit lane"}
+          </p>
+          <h3 class="mt-2 text-lg font-semibold text-ink">{executionRail.commitTitle}</h3>
+          <p class="mt-2 text-sm leading-6 text-slate-600">{executionRail.commitSummary}</p>
+          {result ? (
+            <div class="mt-4">
+              <a class="btn btn-ghost btn-sm" href="#group-builder-panel">
+                {executionRail.jumpLabel}
+              </a>
+            </div>
+          ) : null}
+        </div>
+      </div>
 
       {decisionBoard && result ? (
         <CompareDecisionSection
@@ -468,17 +621,6 @@ export function ComparePage() {
         />
       ) : null}
 
-      <SavedEvidenceSection
-        compareText={compareText}
-        copySavedEvidenceSummary={handleCopyEvidenceSummary}
-        locale={locale}
-        savedPackages={savedPackages}
-        selectedPackageId={selectedPackageId}
-        selectedSavedPackage={selectedSavedPackage}
-        selectSavedPackage={setSelectedPackageId}
-        t={t}
-      />
-
       {result ? (
         <CandidateEvidenceSection
           compareText={compareText}
@@ -494,23 +636,40 @@ export function ComparePage() {
 
       {result ? (
         <div class="grid gap-4 xl:grid-cols-[1.1fr,0.9fr]">
-          <GroupBuilderSection
-            compareText={compareText}
-            comparisonByCandidateKey={comparisonByCandidateKey}
-            createGroup={onCreateGroup}
-            createGroupPending={createGroupMutation.isPending}
-            groupError={groupError}
-            groupForm={groupForm}
-            groupReadyCandidates={groupReadyCandidates}
-            locale={locale}
-            t={t}
-            updateGroupForm={updateGroupForm}
-          />
+          <div id="group-builder-panel">
+            <GroupBuilderSection
+              compareText={compareText}
+              comparisonByCandidateKey={comparisonByCandidateKey}
+              createGroup={onCreateGroup}
+              createGroupPending={createGroupMutation.isPending}
+              groupError={groupError}
+              groupForm={groupForm}
+              groupReadyCandidates={groupReadyCandidates}
+              locale={locale}
+              t={t}
+              updateGroupForm={updateGroupForm}
+            />
+          </div>
           <PairEvidenceSection
             compareText={compareText}
             comparisonByCandidateKey={comparisonByCandidateKey}
             locale={locale}
             matches={result.matches}
+            t={t}
+          />
+        </div>
+      ) : null}
+
+      {savedPackages.length > 0 || result ? (
+        <div id="saved-evidence-panel">
+          <SavedEvidenceSection
+            compareText={compareText}
+            copySavedEvidenceSummary={handleCopyEvidenceSummary}
+            locale={locale}
+            savedPackages={savedPackages}
+            selectedPackageId={selectedPackageId}
+            selectedSavedPackage={selectedSavedPackage}
+            selectSavedPackage={setSelectedPackageId}
             t={t}
           />
         </div>

--- a/frontend/src/pages/ComparePage.tsx
+++ b/frontend/src/pages/ComparePage.tsx
@@ -44,7 +44,7 @@ import {
 } from "./compare/sections";
 
 function compareExecutionCopy(
-  locale: string,
+  t: (key: string) => string,
   values: {
     hasDecision: boolean;
     hasSavedPackage: boolean;
@@ -62,54 +62,32 @@ function compareExecutionCopy(
   runtimeLabel: string;
   jumpLabel: string;
 } {
-  if (locale === "zh-CN") {
-    return {
-      laneTitle: values.hasDecision ? "下一步：按 decision board 行动" : "下一步：先跑出 compare 结果",
-      laneSummary: values.hasDecision
-        ? "别直接跳去建 watch。先看 decision board 推荐的是继续 review、建 group，还是只保留证据。"
-        : "先提交至少两条 URL，让 compare 结果把 basket 里最强的一行和最该警惕的风险说清楚。",
-      proofTitle: values.hasRuntimePackage
-        ? "证据已进入 runtime 包"
-        : values.hasSavedPackage
-          ? "证据已本地保存，仍可继续加固"
-          : "证据还没落袋",
-      proofSummary: values.hasRuntimePackage
-        ? "这轮 compare 已经有 runtime-backed proof，可以带着清楚的边界继续往下走。"
-        : values.hasSavedPackage
-          ? "本地 evidence package 已保存。下一步只有在这篮子还站得住时，才值得继续铸成 runtime 包。"
-          : "先把 evidence package 存下来，再谈 commit。这样你回头复核时不会只剩一张好看的页面。",
-      commitTitle: values.groupReadyCount >= 2 ? "可以考虑进入 compare-aware watch group" : "还不到 commit 成 group 的时机",
-      commitSummary: values.groupReadyCount >= 2
-        ? `当前已有 ${values.groupReadyCount} 个 group-ready 行，可以进入 watch group builder，但前提还是证据先站稳。`
-        : "现在更像 review lane，不像 commit lane。先把支持度不足的行留在证据层，不要急着变成长期 watch state。",
-      saveLabel: "先保存本地证据",
-      runtimeLabel: "再铸成 runtime 包",
-      jumpLabel: "查看 commit 入口",
-    };
-  }
-
   return {
-    laneTitle: values.hasDecision ? "Next move: follow the decision board" : "Next move: generate a clean compare result",
+    laneTitle: values.hasDecision
+      ? t("compare.execution.lane.title.ready")
+      : t("compare.execution.lane.title.idle"),
     laneSummary: values.hasDecision
-      ? "Do not jump straight into watch creation. Use the decision board to decide whether this basket should stay in review, become a group, or stop at evidence."
-      : "Submit at least two URLs first so the compare run can name the strongest row and the sharpest risk inside the basket.",
+      ? t("compare.execution.lane.summary.ready")
+      : t("compare.execution.lane.summary.idle"),
     proofTitle: values.hasRuntimePackage
-      ? "Proof already has a runtime-backed package"
+      ? t("compare.execution.proof.title.runtime")
       : values.hasSavedPackage
-        ? "Proof is saved locally and still reviewable"
-        : "Proof is not stored yet",
+        ? t("compare.execution.proof.title.local")
+        : t("compare.execution.proof.title.empty"),
     proofSummary: values.hasRuntimePackage
-      ? "This compare run already has a runtime-backed proof package, so the next move can stay honest without pretending the basket is final."
+      ? t("compare.execution.proof.summary.runtime")
       : values.hasSavedPackage
-        ? "A local evidence package exists. Promote it only if the basket still stands up after review."
-        : "Save the evidence package before you commit anything. That way the proof survives even if the basket needs one more review pass.",
-    commitTitle: values.groupReadyCount >= 2 ? "This basket can move toward a compare-aware watch group" : "This basket is not ready to commit into a group yet",
+        ? t("compare.execution.proof.summary.local")
+        : t("compare.execution.proof.summary.empty"),
+    commitTitle: values.groupReadyCount >= 2
+      ? t("compare.execution.commit.title.ready")
+      : t("compare.execution.commit.title.idle"),
     commitSummary: values.groupReadyCount >= 2
-      ? `${values.groupReadyCount} rows are group-ready, so the group builder can become the final lane after the proof is preserved.`
-      : "This still behaves like a review lane, not a commit lane. Keep weaker rows in evidence instead of freezing them into long-lived watch state.",
-    saveLabel: "Save local proof first",
-    runtimeLabel: "Then mint runtime proof",
-    jumpLabel: "Open commit lane",
+      ? t("compare.execution.commit.summary.ready").replace("{{count}}", String(values.groupReadyCount))
+      : t("compare.execution.commit.summary.idle"),
+    saveLabel: t("compare.execution.proof.saveLabel"),
+    runtimeLabel: t("compare.execution.proof.runtimeLabel"),
+    jumpLabel: t("compare.execution.commit.jumpLabel"),
   };
 }
 
@@ -297,7 +275,7 @@ export function ComparePage() {
     }
     return savedPackages.find((item) => item.id === draftPackageId)?.runtimeArtifact ?? null;
   }, [draftPackageId, savedPackages]);
-  const executionRail = compareExecutionCopy(locale, {
+  const executionRail = compareExecutionCopy(t, {
     hasDecision: Boolean(decisionBoard),
     hasSavedPackage: savedPackages.length > 0 || Boolean(draftPackageId),
     hasRuntimePackage: Boolean(currentRuntimePackage),
@@ -558,7 +536,7 @@ export function ComparePage() {
       <div class="grid gap-4 xl:grid-cols-[1.1fr,0.9fr,0.9fr]">
         <div class="rounded-[1.5rem] border border-ink/10 bg-base-100/95 p-5 shadow-card">
           <p class="text-[11px] font-semibold uppercase tracking-[0.16em] text-slate-500">
-            {locale === "zh-CN" ? "执行路线" : "Execution lane"}
+            {t("compare.execution.lane.label")}
           </p>
           <h3 class="mt-2 text-lg font-semibold text-ink">{executionRail.laneTitle}</h3>
           <p class="mt-2 text-sm leading-6 text-slate-600">{executionRail.laneSummary}</p>
@@ -566,7 +544,7 @@ export function ComparePage() {
 
         <div class="rounded-[1.5rem] border border-ember/20 bg-ember/5 p-5 shadow-card">
           <p class="text-[11px] font-semibold uppercase tracking-[0.16em] text-ember">
-            {locale === "zh-CN" ? "证明路线" : "Proof lane"}
+            {t("compare.execution.proof.label")}
           </p>
           <h3 class="mt-2 text-lg font-semibold text-ink">{executionRail.proofTitle}</h3>
           <p class="mt-2 text-sm leading-6 text-slate-700">{executionRail.proofSummary}</p>
@@ -589,7 +567,7 @@ export function ComparePage() {
 
         <div class="rounded-[1.5rem] border border-base-300 bg-base-100/95 p-5 shadow-card">
           <p class="text-[11px] font-semibold uppercase tracking-[0.16em] text-slate-500">
-            {locale === "zh-CN" ? "提交路线" : "Commit lane"}
+            {t("compare.execution.commit.label")}
           </p>
           <h3 class="mt-2 text-lg font-semibold text-ink">{executionRail.commitTitle}</h3>
           <p class="mt-2 text-sm leading-6 text-slate-600">{executionRail.commitSummary}</p>

--- a/site/data/i18n/en.json
+++ b/site/data/i18n/en.json
@@ -21,6 +21,33 @@
     "primaryNavLabel": "Primary lanes",
     "secondaryNavLabel": "Context lane",
     "secondaryHint": "Detail views appear after you open or create a task or group.",
+    "focus": {
+      "proofLabel": "Proof path",
+      "compare": {
+        "label": "Current focus",
+        "headline": "Cleanly compare the basket before moving anything into watch state",
+        "summary": "Compare at least two product URLs first, let the decision board explain what is strong and what is still shaky, then decide between a watch group or evidence-only review.",
+        "proofPath": "Save a local evidence package first; only move into runtime packages or watch groups once the basket is honest enough."
+      },
+      "watchNew": {
+        "label": "Current focus",
+        "headline": "Turn one confirmed row into executable watch state",
+        "summary": "This lane only matters after the compare result is honest enough. Confirm the title, candidate key, and recipient before you commit.",
+        "proofPath": "Keep the compare package first, then treat the one-row watch task as the final move."
+      },
+      "watchList": {
+        "label": "Current focus",
+        "headline": "Review which watches still need confirmation before adding more URLs",
+        "summary": "If watches or groups are already queued, return to their evidence and cooldown state before starting another compare run.",
+        "proofPath": "The watch list only consumes compare results that already stand on solid evidence; it does not replace compare itself."
+      },
+      "settings": {
+        "label": "Current focus",
+        "headline": "Tune the reminder cadence into a trustworthy execution surface",
+        "summary": "This is not the primary lane, but it decides whether later alerts become noise. Confirm the recipient and cooldown before you go back to compare.",
+        "proofPath": "Settings enforce discipline; they do not create the decision itself."
+      }
+    },
     "nav": {
       "compare": "Compare",
       "watchList": "Watches",
@@ -61,6 +88,46 @@
       "stepDecisionSummary": "Use the headline, risk summary, and strongest pair before you create anything durable.",
       "stepCommitTitle": "Commit the right state",
       "stepCommitSummary": "Create one watch task for a clear single row, or a watch group only when the basket truly holds together."
+    },
+    "execution": {
+      "lane": {
+        "label": "Execution lane",
+        "title": {
+          "idle": "Next move: generate a clean compare result",
+          "ready": "Next move: follow the decision board"
+        },
+        "summary": {
+          "idle": "Submit at least two URLs first so the compare run can name the strongest row and the sharpest risk inside the basket.",
+          "ready": "Do not jump straight into watch creation. Use the decision board to decide whether this basket should stay in review, become a group, or stop at evidence."
+        }
+      },
+      "proof": {
+        "label": "Proof lane",
+        "title": {
+          "empty": "Proof is not stored yet",
+          "local": "Proof is saved locally and still reviewable",
+          "runtime": "Proof already has a runtime-backed package"
+        },
+        "summary": {
+          "empty": "Save the evidence package before you commit anything. That way the proof survives even if the basket needs one more review pass.",
+          "local": "A local evidence package exists. Promote it only if the basket still stands up after review.",
+          "runtime": "This compare run already has a runtime-backed proof package, so the next move can stay honest without pretending the basket is final."
+        },
+        "saveLabel": "Save local proof first",
+        "runtimeLabel": "Then mint runtime proof"
+      },
+      "commit": {
+        "label": "Commit lane",
+        "title": {
+          "idle": "This basket is not ready to commit into a group yet",
+          "ready": "This basket can move toward a compare-aware watch group"
+        },
+        "summary": {
+          "idle": "This still behaves like a review lane, not a commit lane. Keep weaker rows in evidence instead of freezing them into long-lived watch state.",
+          "ready": "{{count}} rows are group-ready, so the group builder can become the final lane after the proof is preserved."
+        },
+        "jumpLabel": "Open commit lane"
+      }
     },
     "decision": {
       "eyebrow": "Decision board",

--- a/site/data/i18n/en.json
+++ b/site/data/i18n/en.json
@@ -14,6 +14,13 @@
     "summary": "Start with Compare Preview, keep the right candidate alive as a watch task or compare-aware watch group, then use runtime evidence, AI-assisted explanations, recovery guidance, and store/operator surfaces from one place.",
     "productShapeLabel": "Current Product Shape",
     "productShapeValue": "URL -> Compare Preview -> WatchTask / WatchGroup -> Runs -> Recovery / Alerts / Store Ops",
+    "primaryPathLabel": "Primary flow",
+    "primaryPathCompare": "Compare",
+    "primaryPathDecision": "Read the decision board",
+    "primaryPathCommit": "Commit the right watch state",
+    "primaryNavLabel": "Primary lanes",
+    "secondaryNavLabel": "Context lane",
+    "secondaryHint": "Detail views appear after you open or create a task or group.",
     "nav": {
       "compare": "Compare",
       "watchList": "Watches",
@@ -31,7 +38,7 @@
     "form": {
       "eyebrow": "Compare preview",
       "title": "Inspect cross-store URL candidates before you create a task or group",
-      "summary": "Think of this page as the intake desk for the product. It helps you decide whether the rows belong in one compare-aware basket, should become a single task, or should stay in review because the evidence is still mixed.",
+      "summary": "Start small: paste the candidate URLs, let DealWatch normalize the basket, then use the decision board to decide whether this should stay in review, become one task, or become a compare-aware group.",
       "zipCode": "ZIP Code",
     "productUrls": "Product URLs",
     "productUrlsHelp": "Use one URL per line. The compare preview accepts 2 to 10 non-empty URLs.",
@@ -44,6 +51,17 @@
       "maxUrls": "Enter no more than ten product URLs."
     }
   },
+    "route": {
+      "eyebrow": "First-success path",
+      "title": "Keep the first screen about one decision, not six doors",
+      "summary": "This page works best when you treat it like a guided desk: compare the rows first, read the decision board second, then commit only the watch state that the evidence actually supports.",
+      "stepCompareTitle": "Compare the basket",
+      "stepCompareSummary": "Paste the URLs and let the product tell you which rows really belong in the same candidate set.",
+      "stepDecisionTitle": "Read the decision board",
+      "stepDecisionSummary": "Use the headline, risk summary, and strongest pair before you create anything durable.",
+      "stepCommitTitle": "Commit the right state",
+      "stepCommitSummary": "Create one watch task for a clear single row, or a watch group only when the basket truly holds together."
+    },
     "decision": {
       "eyebrow": "Decision board",
       "recommendedNextStep": "Recommended next step",
@@ -911,6 +929,14 @@
       "heroKicker": "Compare-first grocery intelligence",
       "heroTitle": "Compare the aisle before you commit to one cart.",
       "heroSummary": "DealWatch is strongest when the real job starts before you save a watch: compare the candidate URLs, keep the cross-store basket alive, then carry the winning row into a local runtime with proof, effective-price context, and alert history still attached.",
+      "routeCompareTitle": "1. Compare Preview",
+      "routeCompareSummary": "See the product on a fixed sample first, before you install anything.",
+      "routeProofTitle": "2. Proof",
+      "routeProofSummary": "Check the verifier trail so the story feels earned, not just advertised.",
+      "routeQuickStartTitle": "3. Quick Start",
+      "routeQuickStartSummary": "Move into the local runtime only after the compare story already makes sense.",
+      "routeBuildersTitle": "Specialist route",
+      "routeBuildersSummary": "Builders stays secondary for Codex, Claude Code, and similar read-only client wiring.",
       "heroPrimaryCta": "Open the sample compare",
       "heroSecondaryCta": "See the proof trail",
       "heroBuilderCta": "Run the local product",

--- a/site/data/i18n/zh-CN.json
+++ b/site/data/i18n/zh-CN.json
@@ -14,6 +14,13 @@
     "summary": "先从 Compare Preview 开始，把最合适的候选保留为 watch task 或 compare-aware watch group，再从同一个控制舱查看运行证据、AI 辅助解释、恢复指引，以及门店和运维信息。",
     "productShapeLabel": "当前产品形态",
     "productShapeValue": "URL -> Compare Preview -> WatchTask / WatchGroup -> 运行记录 -> 恢复 / 提醒 / 门店运维",
+    "primaryPathLabel": "主路线",
+    "primaryPathCompare": "先比价",
+    "primaryPathDecision": "读懂决策看板",
+    "primaryPathCommit": "再提交正确的监控状态",
+    "primaryNavLabel": "主入口",
+    "secondaryNavLabel": "上下文入口",
+    "secondaryHint": "只有当你打开或创建了任务 / 分组，详情入口才会出现。",
     "nav": {
       "compare": "比价",
       "watchList": "监控列表",
@@ -31,7 +38,7 @@
     "form": {
       "eyebrow": "比价预览",
       "title": "先检查跨门店 URL 候选，再决定是否创建任务或分组",
-      "summary": "把这个页面理解成产品的“收件台”。它帮助你判断这些候选应该进入同一个 compare-aware basket、拆成单项任务，还是因为证据仍然混杂而先留在复核区。",
+      "summary": "先把候选 URL 贴进来，让 DealWatch 规范化这个篮子，再根据决策看板判断它该继续留在复核区、变成单任务，还是升级成 compare-aware group。",
       "zipCode": "邮编",
     "productUrls": "商品链接",
     "productUrlsHelp": "每行填写一个 URL。Compare Preview 接受 2 到 10 个非空链接。",
@@ -44,6 +51,17 @@
       "maxUrls": "最多输入十个商品 URL。"
     }
   },
+    "route": {
+      "eyebrow": "首个成功路径",
+      "title": "第一屏要围绕一个决策，而不是六扇门同时喊你",
+      "summary": "把这里理解成一张有向导的工作台：先比较候选，再读决策看板，最后只提交证据真正支持的那种 watch 状态。",
+      "stepCompareTitle": "先比较这个篮子",
+      "stepCompareSummary": "先贴 URL，让产品告诉你哪些行真的属于同一个候选集合。",
+      "stepDecisionTitle": "再读决策看板",
+      "stepDecisionSummary": "先看 headline、风险摘要和最强配对，再决定要不要创建长期状态。",
+      "stepCommitTitle": "最后提交正确状态",
+      "stepCommitSummary": "如果只有一行足够清楚，就建单任务；只有当整个篮子真的站得住，才建 watch group。"
+    },
     "decision": {
       "eyebrow": "决策看板",
       "recommendedNextStep": "推荐下一步",
@@ -911,6 +929,14 @@
       "heroKicker": "以 compare-first 为核心的价格情报",
       "heroTitle": "先比较整条货架，再决定放进哪辆购物车。",
       "heroSummary": "DealWatch 最强的地方，是在你保存 watch 之前就开始帮你做决策：先比较候选 URL，保留跨门店篮子，再把真正值得长期跟踪的那一行带进本地运行栈，同时保留 proof、到手价上下文和提醒历史。",
+      "routeCompareTitle": "1. Compare Preview",
+      "routeCompareSummary": "先看固定样例把产品讲明白，再决定要不要安装任何东西。",
+      "routeProofTitle": "2. Proof",
+      "routeProofSummary": "先核对验证链路，让这个故事像拿出了证据，而不是只会宣传。",
+      "routeQuickStartTitle": "3. Quick Start",
+      "routeQuickStartSummary": "只有当 compare 故事已经讲清楚时，才进入本地运行栈。",
+      "routeBuildersTitle": "专业路线",
+      "routeBuildersSummary": "Builders 继续留给 Codex、Claude Code 等只读 client 接线场景，不抢首页主线。",
       "heroPrimaryCta": "打开样例 compare",
       "heroSecondaryCta": "查看 proof 链路",
       "heroBuilderCta": "运行本地产品",

--- a/site/data/i18n/zh-CN.json
+++ b/site/data/i18n/zh-CN.json
@@ -21,6 +21,33 @@
     "primaryNavLabel": "主入口",
     "secondaryNavLabel": "上下文入口",
     "secondaryHint": "只有当你打开或创建了任务 / 分组，详情入口才会出现。",
+    "focus": {
+      "proofLabel": "证据路径",
+      "compare": {
+        "label": "当前重点",
+        "headline": "先把 basket 比干净，再决定是否进入 watch state",
+        "summary": "先比较至少两条商品 URL，让 decision board 说清楚谁更强、哪里还不稳，再决定是建 group 还是只保留证据。",
+        "proofPath": "先保存本地 evidence package；只有在 basket 足够诚实时，才继续创建 runtime package 或 watch group。"
+      },
+      "watchNew": {
+        "label": "当前重点",
+        "headline": "把已确认的一行变成可执行 watch state",
+        "summary": "这里只有在 compare 结果已经站住脚之后才值得继续。先把标题、候选键和提醒人填对，再提交。",
+        "proofPath": "先保留 compare 包，再把单行 watch task 当成最后一步。"
+      },
+      "watchList": {
+        "label": "当前重点",
+        "headline": "先看哪些 watch 还需要人确认，不要直接继续加新 URL",
+        "summary": "如果已有 watch 或 group 在排队，就先回到它们的证据和冷却状态，再决定是否重新 compare。",
+        "proofPath": "watch list 只吃已经站稳的 compare 结果，不替代 compare 本身。"
+      },
+      "settings": {
+        "label": "当前重点",
+        "headline": "把提醒节奏调成可信执行面",
+        "summary": "这里不是主入口，但它决定后面的提醒有没有噪音。先确认收件人和冷却时间，再回 compare。",
+        "proofPath": "设置页负责守纪律，不负责制造结论。"
+      }
+    },
     "nav": {
       "compare": "比价",
       "watchList": "监控列表",
@@ -61,6 +88,46 @@
       "stepDecisionSummary": "先看 headline、风险摘要和最强配对，再决定要不要创建长期状态。",
       "stepCommitTitle": "最后提交正确状态",
       "stepCommitSummary": "如果只有一行足够清楚，就建单任务；只有当整个篮子真的站得住，才建 watch group。"
+    },
+    "execution": {
+      "lane": {
+        "label": "执行路线",
+        "title": {
+          "idle": "下一步：先跑出 compare 结果",
+          "ready": "下一步：按 decision board 行动"
+        },
+        "summary": {
+          "idle": "先提交至少两条 URL，让 compare 结果把 basket 里最强的一行和最该警惕的风险说清楚。",
+          "ready": "别直接跳去建 watch。先看 decision board 推荐的是继续 review、建 group，还是只保留证据。"
+        }
+      },
+      "proof": {
+        "label": "证明路线",
+        "title": {
+          "empty": "证据还没落袋",
+          "local": "证据已本地保存，仍可继续加固",
+          "runtime": "证据已进入 runtime 包"
+        },
+        "summary": {
+          "empty": "先把 evidence package 存下来，再谈 commit。这样你回头复核时不会只剩一张好看的页面。",
+          "local": "本地 evidence package 已保存。下一步只有在这篮子还站得住时，才值得继续铸成 runtime 包。",
+          "runtime": "这轮 compare 已经有 runtime-backed proof，可以带着清楚的边界继续往下走。"
+        },
+        "saveLabel": "先保存本地证据",
+        "runtimeLabel": "再铸成 runtime 包"
+      },
+      "commit": {
+        "label": "提交路线",
+        "title": {
+          "idle": "还不到 commit 成 group 的时机",
+          "ready": "可以考虑进入 compare-aware watch group"
+        },
+        "summary": {
+          "idle": "现在更像 review lane，不像 commit lane。先把支持度不足的行留在证据层，不要急着变成长期 watch state。",
+          "ready": "当前已有 {{count}} 个 group-ready 行，可以进入 watch group builder，但前提还是证据先站稳。"
+        },
+        "jumpLabel": "查看 commit 入口"
+      }
     },
     "decision": {
       "eyebrow": "决策看板",

--- a/site/index.html
+++ b/site/index.html
@@ -49,12 +49,9 @@
         <nav class="nav">
           <a href="./" data-i18n="site.common.home">Home</a>
           <a href="./compare-preview.html" data-i18n="site.common.comparePreview">Compare Preview</a>
+          <a href="./proof.html" data-i18n="site.common.proof">Proof</a>
           <a href="./quick-start.html" data-i18n="site.common.quickStart">Quick Start</a>
           <a href="./builders.html" data-i18n="site.common.builders">Builders</a>
-          <a href="./compare-vs-tracker.html" data-i18n="site.common.comparison">Comparison</a>
-          <a href="./proof.html" data-i18n="site.common.proof">Proof</a>
-          <a href="./use-cases.html" data-i18n="site.common.useCases">Use Cases</a>
-          <a href="./community.html" data-i18n="site.common.community">Community</a>
           <a href="./faq.html" data-i18n="site.common.faq">FAQ</a>
         </nav>
         <div class="locale-switcher" data-i18n-aria-label="site.common.localeLabel">
@@ -73,6 +70,24 @@
             candidate URLs, keep the cross-store basket alive, then carry the winning row into a
             local runtime with proof, effective-price context, and alert history still attached.
           </p>
+          <div class="flow" style="margin-top: 22px;">
+            <div class="step">
+              <strong data-i18n="site.index.routeCompareTitle">1. Compare Preview</strong>
+              <span data-i18n="site.index.routeCompareSummary">See the product on a fixed sample first, before you install anything.</span>
+            </div>
+            <div class="step">
+              <strong data-i18n="site.index.routeProofTitle">2. Proof</strong>
+              <span data-i18n="site.index.routeProofSummary">Check the verifier trail so the story feels earned, not just advertised.</span>
+            </div>
+            <div class="step">
+              <strong data-i18n="site.index.routeQuickStartTitle">3. Quick Start</strong>
+              <span data-i18n="site.index.routeQuickStartSummary">Move into the local runtime only after the compare story already makes sense.</span>
+            </div>
+            <div class="step">
+              <strong data-i18n="site.index.routeBuildersTitle">Specialist route</strong>
+              <span data-i18n="site.index.routeBuildersSummary">Builders stays secondary for Codex, Claude Code, and similar read-only client wiring.</span>
+            </div>
+          </div>
           <div class="cta-row">
             <a class="button" href="./compare-preview.html#sample-compare-demo" data-i18n="site.index.heroPrimaryCta">Open the sample compare</a>
             <a class="button-secondary" href="./proof.html" data-i18n="site.index.heroSecondaryCta">See the proof trail</a>

--- a/tests/test_frontend_compare_smoke.py
+++ b/tests/test_frontend_compare_smoke.py
@@ -37,9 +37,9 @@ def test_compare_frontend_smoke_keeps_second_pass_flow_discoverable() -> None:
     # compare -> save local proof -> mint runtime proof
     assert "handleSaveEvidencePackage" in compare_page
     assert "handleCreateRuntimeEvidencePackage" in compare_page
-    assert 'Execution lane' in compare_page
-    assert 'Proof lane' in compare_page
-    assert 'Commit lane' in compare_page
+    assert 'compare.execution.lane.label' in compare_page
+    assert 'compare.execution.proof.label' in compare_page
+    assert 'compare.execution.commit.label' in compare_page
     assert 'id="saved-evidence-panel"' in compare_page
     assert 'id="group-builder-panel"' in compare_page
     assert 'href="#group-builder-panel"' in compare_page
@@ -59,6 +59,7 @@ def test_compare_frontend_smoke_keeps_second_pass_flow_discoverable() -> None:
     assert 'buildShellFocus' in app_shell
     assert 'common.languageLabel' in app_shell
     assert 'shell.secondaryHint' in app_shell
+    assert 'shell.focus.proofLabel' in app_shell
 
 
 def test_compare_frontend_smoke_catalogs_cover_route_and_locale_copy() -> None:

--- a/tests/test_frontend_compare_smoke.py
+++ b/tests/test_frontend_compare_smoke.py
@@ -1,0 +1,296 @@
+from __future__ import annotations
+
+import re
+from functools import partial
+from http.server import SimpleHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+from threading import Thread
+from urllib.parse import urlparse
+
+from playwright.sync_api import Route, expect, sync_playwright
+
+
+FRONTEND_DIST = Path(__file__).resolve().parents[1] / "frontend" / "dist"
+
+
+def _compare_payload() -> dict:
+    return {
+        "submitted_count": 2,
+        "resolved_count": 2,
+        "comparisons": [
+            {
+                "submitted_url": "https://www.sayweee.com/product/example-a",
+                "supported": True,
+                "store_key": "weee",
+                "normalized_url": "https://www.sayweee.com/product/example-a",
+                "fetch_succeeded": True,
+                "candidate_key": "weee::example-a",
+                "brand_hint": "Acme",
+                "size_hint": "16 oz",
+                "support_contract": {
+                    "support_channel": "official",
+                    "store_support_tier": "official_full",
+                    "support_reason_codes": ["official_store_registry", "compare_intake"],
+                    "next_step_codes": ["save_compare_evidence", "create_watch_task", "create_watch_group"],
+                    "intake_status": "supported",
+                    "summary": "This row is fully supported for compare, watch tasks, and compare-aware groups.",
+                    "next_step": "Save proof first, then choose between a single watch task or a group.",
+                    "can_save_compare_evidence": True,
+                    "can_create_watch_task": True,
+                    "can_create_watch_group": True,
+                    "cashback_supported": True,
+                    "notifications_supported": True,
+                    "missing_capabilities": [],
+                },
+                "offer": {
+                    "store_id": "weee",
+                    "product_key": "example-a",
+                    "deal_id": "deal-a",
+                    "title": "Acme Jasmine Rice",
+                    "url": "https://www.sayweee.com/product/example-a",
+                    "price": 6.49,
+                    "original_price": 7.29,
+                    "fetch_at": "2026-04-10T08:30:00Z",
+                    "context": {
+                        "region": "Seattle",
+                        "currency": "USD",
+                        "is_member": False,
+                    },
+                    "unit_price_info": {
+                        "unit": "oz",
+                        "value": 16,
+                    },
+                },
+            },
+            {
+                "submitted_url": "https://www.target.com/p/example-b",
+                "supported": True,
+                "store_key": "target",
+                "normalized_url": "https://www.target.com/p/example-b",
+                "fetch_succeeded": True,
+                "candidate_key": "target::example-b",
+                "brand_hint": "Acme",
+                "size_hint": "16 oz",
+                "support_contract": {
+                    "support_channel": "official",
+                    "store_support_tier": "official_full",
+                    "support_reason_codes": ["official_store_registry", "compare_intake"],
+                    "next_step_codes": ["save_compare_evidence", "create_watch_task", "create_watch_group"],
+                    "intake_status": "supported",
+                    "summary": "This row is also ready for compare, watch tasks, and group creation.",
+                    "next_step": "Keep it in the same basket so the runtime can keep reranking.",
+                    "can_save_compare_evidence": True,
+                    "can_create_watch_task": True,
+                    "can_create_watch_group": True,
+                    "cashback_supported": True,
+                    "notifications_supported": True,
+                    "missing_capabilities": [],
+                },
+                "offer": {
+                    "store_id": "target",
+                    "product_key": "example-b",
+                    "deal_id": "deal-b",
+                    "title": "Acme Jasmine Rice",
+                    "url": "https://www.target.com/p/example-b",
+                    "price": 6.99,
+                    "original_price": 7.49,
+                    "fetch_at": "2026-04-10T08:31:00Z",
+                    "context": {
+                        "region": "Seattle",
+                        "currency": "USD",
+                        "is_member": True,
+                    },
+                    "unit_price_info": {
+                        "unit": "oz",
+                        "value": 16,
+                    },
+                },
+            },
+        ],
+        "matches": [
+            {
+                "left_store_key": "weee",
+                "left_product_key": "example-a",
+                "right_store_key": "target",
+                "right_product_key": "example-b",
+                "score": 92.0,
+                "title_similarity": 97.0,
+                "brand_signal": "match",
+                "size_signal": "match",
+                "product_key_signal": "close_match",
+                "left_candidate_key": "weee::example-a",
+                "right_candidate_key": "target::example-b",
+                "why_like": [
+                    "Both rows carry the same Acme Jasmine Rice title.",
+                    "Both sizes resolve to 16 oz.",
+                ],
+                "why_unlike": [
+                    "Target is still priced slightly higher.",
+                ],
+            }
+        ],
+        "recommendation": {
+            "contract_version": "compare_preview_public_v1",
+            "surface": "compare_preview",
+            "scope": "local_runtime_compare_flow",
+            "visibility": "user_visible",
+            "status": "issued",
+            "verdict": "wait",
+            "verdict_vocabulary": ["wait", "recheck_later", "insufficient_evidence"],
+            "headline": "The basket is ready for a compare-aware watch group",
+            "summary": "Weee currently looks like the clearest low-price row, but the stronger next move is to keep both rows in the basket and let the runtime keep reranking.",
+            "basis": [
+                "Two official-full rows resolved with live offers.",
+                "The strongest pair score is above the group-ready threshold.",
+            ],
+            "uncertainty_notes": [
+                "Target is slightly more expensive right now.",
+            ],
+            "abstention": {
+                "active": False,
+                "code": None,
+                "reason": None,
+            },
+            "evidence_refs": [
+                {
+                    "code": "pair_score",
+                    "label": "Strongest pair",
+                    "anchor": "weee::example-a -> target::example-b",
+                }
+            ],
+            "deterministic_primary_note": "Deterministic compare evidence stays primary.",
+            "feedback_boundary": "Operator judgment still owns the final commit move.",
+            "override_boundary": "The UI explains the proof but does not make the final buying decision for you.",
+            "buy_now_blocked": True,
+        },
+        "recommended_next_step_hint": {
+            "action": "create_watch_group",
+            "reason_code": "group_ready",
+            "summary": "Save proof first, then move this basket into a compare-aware watch group.",
+            "successful_candidate_count": 2,
+            "strongest_match_score": 92.0,
+        },
+        "risk_notes": [
+            "Target is still slightly more expensive.",
+        ],
+        "risk_note_items": [
+            {
+                "code": "minor_price_gap",
+                "message": "Target is still slightly more expensive.",
+            }
+        ],
+        "ai_explain": {
+            "status": "ok",
+            "title": "AI-assisted explanation",
+            "summary": "The deterministic board already has enough proof to keep both rows alive.",
+            "detail": "Save the proof first, then let the runtime keep the basket honest over time.",
+            "bullets": [
+                "Weee is currently the lower listed row.",
+                "Both rows are strong enough to stay together in a compare-aware group.",
+            ],
+        },
+    }
+
+
+def _notification_settings_payload() -> dict:
+    return {
+        "default_recipient_email": "owner@example.com",
+        "cooldown_minutes": 240,
+        "notifications_enabled": True,
+    }
+
+
+def _runtime_package_payload() -> dict:
+    return {
+        "id": "runtime-proof-1",
+        "created_at": "2026-04-10T08:35:00Z",
+        "html_url": "http://127.0.0.1:4173/runtime-proof-1.html",
+        "summary_path": ".runtime-cache/evidence/runtime-proof-1.json",
+    }
+
+
+def _api_handler(route: Route) -> None:
+    request = route.request
+    path = urlparse(request.url).path
+
+    if path == "/api/settings/notifications" and request.method == "GET":
+        route.fulfill(status=200, json=_notification_settings_payload())
+        return
+
+    if path == "/api/compare/preview" and request.method == "POST":
+        route.fulfill(status=200, json=_compare_payload())
+        return
+
+    if path == "/api/compare/evidence-packages" and request.method == "POST":
+        route.fulfill(status=200, json=_runtime_package_payload())
+        return
+
+    route.fulfill(status=404, json={"detail": f"Unhandled smoke route: {path}"})
+
+
+class _StaticHandler(SimpleHTTPRequestHandler):
+    def __init__(self, *args, directory: str, **kwargs):
+        super().__init__(*args, directory=directory, **kwargs)
+
+    def log_message(self, format: str, *args) -> None:  # noqa: A003
+        return
+
+
+def _serve_frontend() -> tuple[ThreadingHTTPServer, str]:
+    server = ThreadingHTTPServer(
+        ("127.0.0.1", 0),
+        partial(_StaticHandler, directory=str(FRONTEND_DIST)),
+    )
+    thread = Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    host, port = server.server_address
+    return server, f"http://{host}:{port}"
+
+
+def test_compare_frontend_smoke_handles_proof_commit_and_locale_switch() -> None:
+    assert FRONTEND_DIST.exists(), "frontend dist is missing; run the frontend build before this smoke."
+
+    server, base_url = _serve_frontend()
+    try:
+        with sync_playwright() as playwright:
+            browser = playwright.chromium.launch()
+            page = browser.new_page()
+            page.route("**/api/**", _api_handler)
+
+            page.goto(f"{base_url}/index.html#compare", wait_until="networkidle")
+
+            expect(page.get_by_role("heading", name="Inspect cross-store URL candidates before you create a task or group")).to_be_visible()
+            page.get_by_role("button", name="Compare URLs").click()
+
+            expect(page.get_by_role("button", name="Save review package")).to_be_visible()
+            expect(page.get_by_text("The basket is ready for a compare-aware watch group")).to_be_visible()
+
+            page.get_by_role("button", name="Save review package").click()
+            expect(page.get_by_text("Saved this compare evidence package for local review on this machine.")).to_be_visible()
+
+            page.get_by_role("button", name="Create runtime evidence package").click()
+            expect(page.get_by_text("Runtime evidence package created. This stays local to the runtime and does not create a public link.")).to_be_visible()
+            expect(page.get_by_text("runtime package ready")).to_be_visible()
+            expect(page.get_by_role("link", name="Open runtime package view")).to_have_attribute("href", "http://127.0.0.1:4173/runtime-proof-1.html")
+
+            page.get_by_role("link", name="Open commit lane").click()
+            expect(page.locator("#group-builder-panel")).to_be_visible()
+            expect(page.get_by_role("button", name="Create watch group from successful candidates")).to_be_visible()
+
+            page.get_by_role("button", name="Create watch task from this row").first.click()
+            expect(page).to_have_url(re.compile(r"#watch-new$"))
+            expect(page.get_by_text("Compare handoff")).to_be_visible()
+            expect(page.get_by_text("weee::example-a")).to_be_visible()
+
+            page.get_by_role("button", name="简体中文").click()
+            expect(page.get_by_text("语言")).to_be_visible()
+            expect(page.get_by_role("button", name="单项监控")).to_be_visible()
+            expect(page.get_by_text("当前重点")).to_be_visible()
+
+            page.get_by_role("button", name="English").click()
+            expect(page.get_by_text("Language")).to_be_visible()
+
+            browser.close()
+    finally:
+        server.shutdown()
+        server.server_close()

--- a/tests/test_frontend_compare_smoke.py
+++ b/tests/test_frontend_compare_smoke.py
@@ -1,296 +1,88 @@
 from __future__ import annotations
 
-import re
-from functools import partial
-from http.server import SimpleHTTPRequestHandler, ThreadingHTTPServer
+import json
 from pathlib import Path
-from threading import Thread
-from urllib.parse import urlparse
-
-from playwright.sync_api import Route, expect, sync_playwright
 
 
-FRONTEND_DIST = Path(__file__).resolve().parents[1] / "frontend" / "dist"
+ROOT = Path(__file__).resolve().parents[1]
+COMPARE_PAGE = ROOT / "frontend" / "src" / "pages" / "ComparePage.tsx"
+COMPARE_SECTIONS = ROOT / "frontend" / "src" / "pages" / "compare" / "sections.tsx"
+CREATE_TASK_PAGE = ROOT / "frontend" / "src" / "pages" / "CreateTaskPage.tsx"
+APP_SHELL = ROOT / "frontend" / "src" / "components" / "AppShell.tsx"
+EN_CATALOG = ROOT / "site" / "data" / "i18n" / "en.json"
+ZH_CATALOG = ROOT / "site" / "data" / "i18n" / "zh-CN.json"
 
 
-def _compare_payload() -> dict:
-    return {
-        "submitted_count": 2,
-        "resolved_count": 2,
-        "comparisons": [
-            {
-                "submitted_url": "https://www.sayweee.com/product/example-a",
-                "supported": True,
-                "store_key": "weee",
-                "normalized_url": "https://www.sayweee.com/product/example-a",
-                "fetch_succeeded": True,
-                "candidate_key": "weee::example-a",
-                "brand_hint": "Acme",
-                "size_hint": "16 oz",
-                "support_contract": {
-                    "support_channel": "official",
-                    "store_support_tier": "official_full",
-                    "support_reason_codes": ["official_store_registry", "compare_intake"],
-                    "next_step_codes": ["save_compare_evidence", "create_watch_task", "create_watch_group"],
-                    "intake_status": "supported",
-                    "summary": "This row is fully supported for compare, watch tasks, and compare-aware groups.",
-                    "next_step": "Save proof first, then choose between a single watch task or a group.",
-                    "can_save_compare_evidence": True,
-                    "can_create_watch_task": True,
-                    "can_create_watch_group": True,
-                    "cashback_supported": True,
-                    "notifications_supported": True,
-                    "missing_capabilities": [],
-                },
-                "offer": {
-                    "store_id": "weee",
-                    "product_key": "example-a",
-                    "deal_id": "deal-a",
-                    "title": "Acme Jasmine Rice",
-                    "url": "https://www.sayweee.com/product/example-a",
-                    "price": 6.49,
-                    "original_price": 7.29,
-                    "fetch_at": "2026-04-10T08:30:00Z",
-                    "context": {
-                        "region": "Seattle",
-                        "currency": "USD",
-                        "is_member": False,
-                    },
-                    "unit_price_info": {
-                        "unit": "oz",
-                        "value": 16,
-                    },
-                },
-            },
-            {
-                "submitted_url": "https://www.target.com/p/example-b",
-                "supported": True,
-                "store_key": "target",
-                "normalized_url": "https://www.target.com/p/example-b",
-                "fetch_succeeded": True,
-                "candidate_key": "target::example-b",
-                "brand_hint": "Acme",
-                "size_hint": "16 oz",
-                "support_contract": {
-                    "support_channel": "official",
-                    "store_support_tier": "official_full",
-                    "support_reason_codes": ["official_store_registry", "compare_intake"],
-                    "next_step_codes": ["save_compare_evidence", "create_watch_task", "create_watch_group"],
-                    "intake_status": "supported",
-                    "summary": "This row is also ready for compare, watch tasks, and group creation.",
-                    "next_step": "Keep it in the same basket so the runtime can keep reranking.",
-                    "can_save_compare_evidence": True,
-                    "can_create_watch_task": True,
-                    "can_create_watch_group": True,
-                    "cashback_supported": True,
-                    "notifications_supported": True,
-                    "missing_capabilities": [],
-                },
-                "offer": {
-                    "store_id": "target",
-                    "product_key": "example-b",
-                    "deal_id": "deal-b",
-                    "title": "Acme Jasmine Rice",
-                    "url": "https://www.target.com/p/example-b",
-                    "price": 6.99,
-                    "original_price": 7.49,
-                    "fetch_at": "2026-04-10T08:31:00Z",
-                    "context": {
-                        "region": "Seattle",
-                        "currency": "USD",
-                        "is_member": True,
-                    },
-                    "unit_price_info": {
-                        "unit": "oz",
-                        "value": 16,
-                    },
-                },
-            },
-        ],
-        "matches": [
-            {
-                "left_store_key": "weee",
-                "left_product_key": "example-a",
-                "right_store_key": "target",
-                "right_product_key": "example-b",
-                "score": 92.0,
-                "title_similarity": 97.0,
-                "brand_signal": "match",
-                "size_signal": "match",
-                "product_key_signal": "close_match",
-                "left_candidate_key": "weee::example-a",
-                "right_candidate_key": "target::example-b",
-                "why_like": [
-                    "Both rows carry the same Acme Jasmine Rice title.",
-                    "Both sizes resolve to 16 oz.",
-                ],
-                "why_unlike": [
-                    "Target is still priced slightly higher.",
-                ],
-            }
-        ],
-        "recommendation": {
-            "contract_version": "compare_preview_public_v1",
-            "surface": "compare_preview",
-            "scope": "local_runtime_compare_flow",
-            "visibility": "user_visible",
-            "status": "issued",
-            "verdict": "wait",
-            "verdict_vocabulary": ["wait", "recheck_later", "insufficient_evidence"],
-            "headline": "The basket is ready for a compare-aware watch group",
-            "summary": "Weee currently looks like the clearest low-price row, but the stronger next move is to keep both rows in the basket and let the runtime keep reranking.",
-            "basis": [
-                "Two official-full rows resolved with live offers.",
-                "The strongest pair score is above the group-ready threshold.",
-            ],
-            "uncertainty_notes": [
-                "Target is slightly more expensive right now.",
-            ],
-            "abstention": {
-                "active": False,
-                "code": None,
-                "reason": None,
-            },
-            "evidence_refs": [
-                {
-                    "code": "pair_score",
-                    "label": "Strongest pair",
-                    "anchor": "weee::example-a -> target::example-b",
-                }
-            ],
-            "deterministic_primary_note": "Deterministic compare evidence stays primary.",
-            "feedback_boundary": "Operator judgment still owns the final commit move.",
-            "override_boundary": "The UI explains the proof but does not make the final buying decision for you.",
-            "buy_now_blocked": True,
-        },
-        "recommended_next_step_hint": {
-            "action": "create_watch_group",
-            "reason_code": "group_ready",
-            "summary": "Save proof first, then move this basket into a compare-aware watch group.",
-            "successful_candidate_count": 2,
-            "strongest_match_score": 92.0,
-        },
-        "risk_notes": [
-            "Target is still slightly more expensive.",
-        ],
-        "risk_note_items": [
-            {
-                "code": "minor_price_gap",
-                "message": "Target is still slightly more expensive.",
-            }
-        ],
-        "ai_explain": {
-            "status": "ok",
-            "title": "AI-assisted explanation",
-            "summary": "The deterministic board already has enough proof to keep both rows alive.",
-            "detail": "Save the proof first, then let the runtime keep the basket honest over time.",
-            "bullets": [
-                "Weee is currently the lower listed row.",
-                "Both rows are strong enough to stay together in a compare-aware group.",
-            ],
-        },
-    }
+def _read(path: Path) -> str:
+    return path.read_text(encoding="utf-8")
 
 
-def _notification_settings_payload() -> dict:
-    return {
-        "default_recipient_email": "owner@example.com",
-        "cooldown_minutes": 240,
-        "notifications_enabled": True,
-    }
+def _catalog(path: Path) -> dict:
+    return json.loads(_read(path))
 
 
-def _runtime_package_payload() -> dict:
-    return {
-        "id": "runtime-proof-1",
-        "created_at": "2026-04-10T08:35:00Z",
-        "html_url": "http://127.0.0.1:4173/runtime-proof-1.html",
-        "summary_path": ".runtime-cache/evidence/runtime-proof-1.json",
-    }
+def _dot_get(payload: dict, key: str):
+    current = payload
+    for segment in key.split("."):
+        current = current[segment]
+    return current
 
 
-def _api_handler(route: Route) -> None:
-    request = route.request
-    path = urlparse(request.url).path
+def test_compare_frontend_smoke_keeps_second_pass_flow_discoverable() -> None:
+    compare_page = _read(COMPARE_PAGE)
+    compare_sections = _read(COMPARE_SECTIONS)
+    create_task_page = _read(CREATE_TASK_PAGE)
+    app_shell = _read(APP_SHELL)
 
-    if path == "/api/settings/notifications" and request.method == "GET":
-        route.fulfill(status=200, json=_notification_settings_payload())
-        return
+    # compare -> save local proof -> mint runtime proof
+    assert "handleSaveEvidencePackage" in compare_page
+    assert "handleCreateRuntimeEvidencePackage" in compare_page
+    assert 'Execution lane' in compare_page
+    assert 'Proof lane' in compare_page
+    assert 'Commit lane' in compare_page
+    assert 'id="saved-evidence-panel"' in compare_page
+    assert 'id="group-builder-panel"' in compare_page
+    assert 'href="#group-builder-panel"' in compare_page
 
-    if path == "/api/compare/preview" and request.method == "POST":
-        route.fulfill(status=200, json=_compare_payload())
-        return
+    assert 'compare.decision.saveReviewPackage' in compare_sections
+    assert 'compare.decision.createRuntimePackage' in compare_sections
+    assert 'compare.savedPanel.openRuntimePackageView' in compare_sections
+    assert 'compare.groupBuilder.createButton' in compare_sections
+    assert 'compare.candidatePanel.createWatchTaskFromRow' in compare_sections
 
-    if path == "/api/compare/evidence-packages" and request.method == "POST":
-        route.fulfill(status=200, json=_runtime_package_payload())
-        return
+    # watch-new discoverability
+    assert 'pendingWatchTaskDraft.value' in create_task_page
+    assert 'Compare handoff' in create_task_page
+    assert 'navigate("compare")' in create_task_page
 
-    route.fulfill(status=404, json={"detail": f"Unhandled smoke route: {path}"})
-
-
-class _StaticHandler(SimpleHTTPRequestHandler):
-    def __init__(self, *args, directory: str, **kwargs):
-        super().__init__(*args, directory=directory, **kwargs)
-
-    def log_message(self, format: str, *args) -> None:  # noqa: A003
-        return
-
-
-def _serve_frontend() -> tuple[ThreadingHTTPServer, str]:
-    server = ThreadingHTTPServer(
-        ("127.0.0.1", 0),
-        partial(_StaticHandler, directory=str(FRONTEND_DIST)),
-    )
-    thread = Thread(target=server.serve_forever, daemon=True)
-    thread.start()
-    host, port = server.server_address
-    return server, f"http://{host}:{port}"
+    # shell discoverability + locale switch still live
+    assert 'buildShellFocus' in app_shell
+    assert 'common.languageLabel' in app_shell
+    assert 'shell.secondaryHint' in app_shell
 
 
-def test_compare_frontend_smoke_handles_proof_commit_and_locale_switch() -> None:
-    assert FRONTEND_DIST.exists(), "frontend dist is missing; run the frontend build before this smoke."
+def test_compare_frontend_smoke_catalogs_cover_route_and_locale_copy() -> None:
+    en = _catalog(EN_CATALOG)
+    zh = _catalog(ZH_CATALOG)
 
-    server, base_url = _serve_frontend()
-    try:
-        with sync_playwright() as playwright:
-            browser = playwright.chromium.launch()
-            page = browser.new_page()
-            page.route("**/api/**", _api_handler)
+    keys = [
+        "common.languageLabel",
+        "common.locale.en",
+        "common.locale.zh-CN",
+        "shell.nav.watchNew",
+        "compare.route.eyebrow",
+        "compare.route.title",
+        "compare.route.summary",
+        "compare.route.stepCompareTitle",
+        "compare.route.stepCompareSummary",
+        "compare.route.stepDecisionTitle",
+        "compare.route.stepDecisionSummary",
+        "compare.route.stepCommitTitle",
+        "compare.route.stepCommitSummary",
+        "compare.decision.saveReviewPackage",
+        "compare.decision.createRuntimePackage",
+    ]
 
-            page.goto(f"{base_url}/index.html#compare", wait_until="networkidle")
-
-            expect(page.get_by_role("heading", name="Inspect cross-store URL candidates before you create a task or group")).to_be_visible()
-            page.get_by_role("button", name="Compare URLs").click()
-
-            expect(page.get_by_role("button", name="Save review package")).to_be_visible()
-            expect(page.get_by_text("The basket is ready for a compare-aware watch group")).to_be_visible()
-
-            page.get_by_role("button", name="Save review package").click()
-            expect(page.get_by_text("Saved this compare evidence package for local review on this machine.")).to_be_visible()
-
-            page.get_by_role("button", name="Create runtime evidence package").click()
-            expect(page.get_by_text("Runtime evidence package created. This stays local to the runtime and does not create a public link.")).to_be_visible()
-            expect(page.get_by_text("runtime package ready")).to_be_visible()
-            expect(page.get_by_role("link", name="Open runtime package view")).to_have_attribute("href", "http://127.0.0.1:4173/runtime-proof-1.html")
-
-            page.get_by_role("link", name="Open commit lane").click()
-            expect(page.locator("#group-builder-panel")).to_be_visible()
-            expect(page.get_by_role("button", name="Create watch group from successful candidates")).to_be_visible()
-
-            page.get_by_role("button", name="Create watch task from this row").first.click()
-            expect(page).to_have_url(re.compile(r"#watch-new$"))
-            expect(page.get_by_text("Compare handoff")).to_be_visible()
-            expect(page.get_by_text("weee::example-a")).to_be_visible()
-
-            page.get_by_role("button", name="简体中文").click()
-            expect(page.get_by_text("语言")).to_be_visible()
-            expect(page.get_by_role("button", name="单项监控")).to_be_visible()
-            expect(page.get_by_text("当前重点")).to_be_visible()
-
-            page.get_by_role("button", name="English").click()
-            expect(page.get_by_text("Language")).to_be_visible()
-
-            browser.close()
-    finally:
-        server.shutdown()
-        server.server_close()
+    for key in keys:
+        assert _dot_get(en, key)
+        assert _dot_get(zh, key)


### PR DESCRIPTION
## Summary
- deepen the compare-first shell and compare page into clearer execution, proof, and commit lanes
- add a narrow frontend smoke covering compare -> local proof -> runtime proof -> watch/group discoverability -> locale switching

## Verification
- pnpm --dir frontend build
- python3 -m py_compile tests/test_frontend_compare_smoke.py
- uv run python -m pytest -q tests/test_frontend_compare_smoke.py