### PR TITLE
fix: close dealwatch refinement truth slice

### DIFF
--- a/DISTRIBUTION.md
+++ b/DISTRIBUTION.md
@@ -4,18 +4,18 @@ This file is the shortest truthful distribution ledger for DealWatch.
 
 ## Current repo-owned distribution reality
 
-| Surface | Repo state now | Honest public claim |
-| --- | --- | --- |
-| GitHub repo | public canonical repo under `xiaojiou176-open/dealwatch` | live |
-| GitHub Pages | homepage, compare preview, proof, FAQ, builders, comparison, community | live |
-| GitHub release/tag | one canonical public release `v0.1.2` | live |
-| Python package | `dealwatch==1.0.1` is published on PyPI and matches the current MCP package surface | live |
-| Official MCP Registry | `io.github.xiaojiou176-open/dealwatch` is published and searchable | live |
-| ClawHub skill | `dealwatch-readonly-builder` is published under the OpenClaw skill registry | live |
-| OpenHands/extensions | active public skill submission is PR [`OpenHands/extensions#151`](https://github.com/OpenHands/extensions/pull/151); PR [`#152`](https://github.com/OpenHands/extensions/pull/152) is the retired predecessor | submission_done_platform_not_accepted_yet (`#151` still carries maintainer-requested changes) |
-| MCP.so submission | server intake issue [`chatmcp/mcpso#1558`](https://github.com/chatmcp/mcpso/issues/1558) is filed, but the public page is still not established | submission_done_platform_not_accepted_yet |
-| Builder pack | starter prompts, skill cards, config exports, native bundle candidates, and listing-prep copy are all repo-owned | repo-owned pack is live; official host truth is mixed by platform |
-| Chrome companion extension | `browser-extension/` package, icons, build script, listing notes | submit-ready for dashboard upload, **not published** |
+| Surface | Exact public receipt today | Repo state now | Honest public claim |
+| --- | --- | --- | --- |
+| GitHub repo | [`github.com/xiaojiou176-open/dealwatch`](https://github.com/xiaojiou176-open/dealwatch) | public canonical repo under `xiaojiou176-open/dealwatch` | live |
+| GitHub Pages | [`xiaojiou176-open.github.io/dealwatch/`](https://xiaojiou176-open.github.io/dealwatch/) | homepage, compare preview, proof, FAQ, builders, comparison, community | live |
+| GitHub release/tag | [`releases/latest`](https://github.com/xiaojiou176-open/dealwatch/releases/latest) | one canonical public release `v0.1.2` | live |
+| Python package | [`pypi.org/project/dealwatch/`](https://pypi.org/project/dealwatch/) | `dealwatch==1.0.1` is published on PyPI and matches the current MCP package surface | live |
+| Official MCP Registry | [`registry.modelcontextprotocol.io/v0.1/servers?search=dealwatch`](https://registry.modelcontextprotocol.io/v0.1/servers?search=dealwatch) | `io.github.xiaojiou176-open/dealwatch` is published and searchable | live |
+| ClawHub skill | [`clawhub.ai/xiaojiou176/dealwatch-readonly-builder`](https://clawhub.ai/xiaojiou176/dealwatch-readonly-builder) | `dealwatch-readonly-builder` is published under the OpenClaw skill registry | live |
+| OpenHands/extensions | active public skill submission is PR [`OpenHands/extensions#151`](https://github.com/OpenHands/extensions/pull/151); PR [`#152`](https://github.com/OpenHands/extensions/pull/152) is the retired predecessor | active public skill submission is PR `#151`; `#152` is retired predecessor | submission_done_platform_not_accepted_yet (`#151` still carries maintainer-requested changes) |
+| MCP.so submission | submission receipt [`chatmcp/mcpso#1558`](https://github.com/chatmcp/mcpso/issues/1558); guessed public page [`mcp.so/server/dealwatch`](https://mcp.so/server/dealwatch) still renders `Project not found` today | server intake issue `#1558` is filed, but there is still no public listing receipt | submission_done_platform_not_accepted_yet |
+| Builder pack | repo-owned pack only | starter prompts, skill cards, config exports, native bundle candidates, and listing-prep copy are all repo-owned | repo-owned pack is live; official host truth is mixed by platform |
+| Chrome companion extension | no public item URL tracked yet | `browser-extension/` package, icons, build script, listing notes | submit-ready for dashboard upload, **not published** |
 
 ## What still remains manual / external
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,8 @@ DealWatch turns “which grocery URL is actually the right target?” into one p
 
 The public boundary stays strict on purpose: DealWatch is local-first, compare-first, and evidence-first. It is not a hosted SaaS, not a generic shopping chatbot, and not an autonomous buying agent. AI helps explain compare, watch-group, and recovery decisions, but deterministic product truth still leads.
 
-[Try the Sample Compare](https://xiaojiou176-open.github.io/dealwatch/compare-preview.html#sample-compare-demo) · [See the Proof](https://xiaojiou176-open.github.io/dealwatch/proof.html) · [Run Local Quick Start](https://xiaojiou176-open.github.io/dealwatch/quick-start.html) · [Builder Route](https://xiaojiou176-open.github.io/dealwatch/builders.html) · [Releases](https://github.com/xiaojiou176-open/dealwatch/releases/latest)
+[Try the Sample Compare](https://xiaojiou176-open.github.io/dealwatch/compare-preview.html#sample-compare-demo) · [See the Proof](https://xiaojiou176-open.github.io/dealwatch/proof.html) · [Run Local Quick Start](https://xiaojiou176-open.github.io/dealwatch/quick-start.html) · [Releases](https://github.com/xiaojiou176-open/dealwatch/releases/latest)  
+Specialist route: [Builder Route](https://xiaojiou176-open.github.io/dealwatch/builders.html)
 
 ![DealWatch control cabin brand bridge showing compare preview, artifact evidence, and notification surfaces](./assets/social/social-preview-1280x640.png)
 

--- a/scripts/verify_public_entrypoints.py
+++ b/scripts/verify_public_entrypoints.py
@@ -21,6 +21,7 @@ REQUIRED_SNIPPETS = {
         "https://xiaojiou176-open.github.io/dealwatch/compare-preview.html#sample-compare-demo",
         "https://xiaojiou176-open.github.io/dealwatch/quick-start.html",
         "https://xiaojiou176-open.github.io/dealwatch/builders.html",
+        "Specialist route: [Builder Route](https://xiaojiou176-open.github.io/dealwatch/builders.html)",
         "https://xiaojiou176-open.github.io/dealwatch/compare-preview.html",
         "https://xiaojiou176-open.github.io/dealwatch/proof.html",
         "./site/builders.html",
@@ -46,6 +47,9 @@ REQUIRED_SNIPPETS = {
         "python3 scripts/verify_remote_github_state.py",
         "python3 scripts/print_remote_repo_settings_checklist.py",
         "https://github.com/xiaojiou176-open/dealwatch/releases/latest",
+    ],
+    ROOT / "site" / "compare-preview.html": [
+        "1 local-runtime API route",
     ],
     SITE_BUILDERS: [
         "https://github.com/xiaojiou176-open/dealwatch/blob/main/docs/roadmaps/dealwatch-api-mcp-substrate-phase1.md",

--- a/site/compare-preview.html
+++ b/site/compare-preview.html
@@ -89,7 +89,7 @@
               <span class="small-note" data-i18n="site.comparePreviewPage.statusReadonlySummary">Compare Preview stays read-only until you intentionally create a task.</span>
             </div>
             <div class="status-pill">
-              <strong data-i18n="site.comparePreviewPage.statusApiTitle">1 live API route</strong>
+              <strong data-i18n="site.comparePreviewPage.statusApiTitle">1 local-runtime API route</strong>
               <span class="small-note" data-i18n="site.comparePreviewPage.statusApiSummary">`POST /api/compare/preview` is the route behind the first product step.</span>
             </div>
             <div class="status-pill">

--- a/site/data/i18n/en.json
+++ b/site/data/i18n/en.json
@@ -1160,7 +1160,7 @@
       "heroSecondaryCta": "Run the local quick start",
       "statusReadonlyTitle": "2 URLs in, 0 durable writes",
       "statusReadonlySummary": "Compare Preview stays read-only until you intentionally create a task.",
-      "statusApiTitle": "1 live API route",
+      "statusApiTitle": "1 local-runtime API route",
       "statusApiSummary": "`POST /api/compare/preview` is the route behind the first product step.",
       "statusAiTitle": "AI explains, evidence stays primary",
       "statusAiSummary": "The current product uses AI-assisted compare explanations, but deterministic compare evidence still remains the source of truth.",


### PR DESCRIPTION
## Summary
- land the current four-file local refinement for README, distribution, compare preview, and en i18n copy
- keep compare-first primary while demoting builders to the specialist route and clarifying the compare preview API as local-runtime only
- add a minimal public-entrypoint verifier guard for the README specialist-route wording and compare-preview local-runtime API wording

## Verification
- `python3 scripts/verify_public_entrypoints.py`
- `uv run pytest tests/test_i18n_surface_alignment.py`