### PR TITLE
docs: sync Cline marketplace receipt status

### DIFF
--- a/DISTRIBUTION.md
+++ b/DISTRIBUTION.md
@@ -12,6 +12,7 @@ This file is the shortest truthful distribution ledger for DealWatch.
 | Python package | [`pypi.org/project/dealwatch/`](https://pypi.org/project/dealwatch/) | `dealwatch==1.0.1` is published on PyPI and matches the current MCP package surface | live |
 | Official MCP Registry | [`registry.modelcontextprotocol.io/v0.1/servers?search=dealwatch`](https://registry.modelcontextprotocol.io/v0.1/servers?search=dealwatch) | `io.github.xiaojiou176-open/dealwatch` is published and searchable | live |
 | ClawHub skill | [`clawhub.ai/xiaojiou176/dealwatch-readonly-builder`](https://clawhub.ai/xiaojiou176/dealwatch-readonly-builder) | `dealwatch-readonly-builder` is published under the OpenClaw skill registry | live |
+| Cline MCP Marketplace | submission receipt [`cline/mcp-marketplace#1325`](https://github.com/cline/mcp-marketplace/issues/1325) | repo-side reviewer cargo already landed on `main` via [`dealwatch#29`](https://github.com/xiaojiou176-open/dealwatch/pull/29); external intake is now waiting on maintainer review | review-pending |
 | OpenHands/extensions | active public skill submission is PR [`OpenHands/extensions#151`](https://github.com/OpenHands/extensions/pull/151); PR [`#152`](https://github.com/OpenHands/extensions/pull/152) is the retired predecessor | active public skill submission is PR `#151`; `#152` is retired predecessor | submission_done_platform_not_accepted_yet (`#151` still carries maintainer-requested changes) |
 | MCP.so submission | submission receipt [`chatmcp/mcpso#1558`](https://github.com/chatmcp/mcpso/issues/1558); guessed public page [`mcp.so/server/dealwatch`](https://mcp.so/server/dealwatch) still renders `Project not found` today | server intake issue `#1558` is filed, but there is still no public listing receipt | submission_done_platform_not_accepted_yet |
 | Builder pack | repo-owned pack only | starter prompts, skill cards, config exports, native bundle candidates, and listing-prep copy are all repo-owned | repo-owned pack is live; official host truth is mixed by platform |
@@ -19,6 +20,7 @@ This file is the shortest truthful distribution ledger for DealWatch.
 
 ## What still remains manual / external
 
+- wait for maintainer review on `cline/mcp-marketplace#1325`; do not claim the Cline lane is listed live before a public marketplace read-back exists
 - respond on the active OpenHands line `OpenHands/extensions#151` until the requested changes are accepted; do not send reviewers to `#152`
 - wait for the public host listing to exist on `chatmcp/mcpso#1558`
 - upload the Chrome companion extension package through the Chrome Web Store dashboard


### PR DESCRIPTION
## Summary
- write the real `cline/mcp-marketplace#1325` receipt back into the repo distribution ledger
- keep the lane at review-pending instead of overstating it as listed/live

## Validation
- `python3 scripts/verify_public_surface.py`
- fresh read-back of `cline/mcp-marketplace#1325` as open review object
