### PR TITLE
docs: tighten external distribution truth claims

### DIFF
--- a/DISTRIBUTION.md
+++ b/DISTRIBUTION.md
@@ -11,9 +11,9 @@ This file is the shortest truthful distribution ledger for DealWatch.
 | GitHub release/tag | [`releases/latest`](https://github.com/xiaojiou176-open/dealwatch/releases/latest) | one canonical public release `v0.1.2` | live |
 | Python package | [`pypi.org/project/dealwatch/`](https://pypi.org/project/dealwatch/) | `dealwatch==1.0.1` is published on PyPI and matches the current MCP package surface | live |
 | Official MCP Registry | [`registry.modelcontextprotocol.io/v0.1/servers?search=dealwatch`](https://registry.modelcontextprotocol.io/v0.1/servers?search=dealwatch) | `io.github.xiaojiou176-open/dealwatch` is published and searchable | live |
-| ClawHub skill | [`clawhub.ai/xiaojiou176/dealwatch-readonly-builder`](https://clawhub.ai/xiaojiou176/dealwatch-readonly-builder) | `dealwatch-readonly-builder` is published under the OpenClaw skill registry | live |
+| ClawHub skill | current public ClawHub search/API does not provide stable DealWatch listing proof | repo-owned `dealwatch-readonly-builder` skill packet and manifest exist, but the host-side live claim is not fresh enough to publish as fact | no_fresh_public_evidence |
 | Cline MCP Marketplace | submission receipt [`cline/mcp-marketplace#1325`](https://github.com/cline/mcp-marketplace/issues/1325) | repo-side reviewer cargo already landed on `main` via [`dealwatch#29`](https://github.com/xiaojiou176-open/dealwatch/pull/29); external intake is now waiting on maintainer review | review-pending |
-| OpenHands/extensions | active public skill submission is PR [`OpenHands/extensions#151`](https://github.com/OpenHands/extensions/pull/151); PR [`#152`](https://github.com/OpenHands/extensions/pull/152) is the retired predecessor | active public skill submission is PR `#151`; `#152` is retired predecessor | submission_done_platform_not_accepted_yet (`#151` still carries maintainer-requested changes) |
+| OpenHands/extensions | closed PR [`OpenHands/extensions#151`](https://github.com/OpenHands/extensions/pull/151); PR [`#152`](https://github.com/OpenHands/extensions/pull/152) is the retired predecessor | repo-owned OpenHands skill packet still exists, but `#151` is closed and unmerged, so it does not count as accepted host proof | closed_unmerged_not_accepted |
 | MCP.so submission | submission receipt [`chatmcp/mcpso#1558`](https://github.com/chatmcp/mcpso/issues/1558); guessed public page [`mcp.so/server/dealwatch`](https://mcp.so/server/dealwatch) still renders `Project not found` today | server intake issue `#1558` is filed, but there is still no public listing receipt | submission_done_platform_not_accepted_yet |
 | Builder pack | repo-owned pack only | starter prompts, skill cards, config exports, native bundle candidates, and listing-prep copy are all repo-owned | repo-owned pack is live; official host truth is mixed by platform |
 | Chrome companion extension | no public item URL tracked yet | `browser-extension/` package, icons, build script, listing notes | submit-ready for dashboard upload, **not published** |
@@ -21,7 +21,7 @@ This file is the shortest truthful distribution ledger for DealWatch.
 ## What still remains manual / external
 
 - wait for maintainer review on `cline/mcp-marketplace#1325`; do not claim the Cline lane is listed live before a public marketplace read-back exists
-- respond on the active OpenHands line `OpenHands/extensions#151` until the requested changes are accepted; do not send reviewers to `#152`
+- if the OpenHands lane matters, restart from the current closed state of `OpenHands/extensions#151` rather than pretending it is still an active review queue
 - wait for the public host listing to exist on `chatmcp/mcpso#1558`
 - upload the Chrome companion extension package through the Chrome Web Store dashboard
 

--- a/INTEGRATIONS.md
+++ b/INTEGRATIONS.md
@@ -13,7 +13,8 @@ Truthful status:
 
 - the read-only MCP and HTTP builder surfaces are shipped
 - starter prompts, skill cards, config exports, and native bundle candidates exist in-repo
-- live public surfaces today are PyPI, the Official MCP Registry, and OpenClaw's ClawHub skill
-- OpenHands is active on `OpenHands/extensions#151` with maintainer-requested changes; `#152` is a retired predecessor, not the current line
+- live public surfaces today are PyPI and the Official MCP Registry
+- OpenClaw currently stays in `repo-owned cargo / no fresh public ClawHub proof yet`
+- OpenHands `OpenHands/extensions#151` is closed and unmerged; `#152` is a retired predecessor, not an active review lane
 - MCP.so is submitted but not yet accepted into a live public page, and the Chrome companion remains **not published**
 - write-side MCP, hosted auth, SDK packaging, and broader builder recommendation claims remain deferred

--- a/docs/integrations/README.md
+++ b/docs/integrations/README.md
@@ -154,9 +154,9 @@ The stable part is:
 | --- | --- | --- | --- |
 | Claude Code | register the local stdio MCP command, then read the substrate doc | `get_runtime_readiness` -> `get_builder_starter_pack` -> `compare_preview` -> `list_watch_tasks` or `list_watch_groups` | no write-side MCP, no hosted remote control plane |
 | Codex | point Codex at the local runtime plus the streamable-HTTP MCP contract | `get_runtime_readiness` -> `get_builder_starter_pack` -> `compare_preview` -> one detail read | no SDK, no multi-tenant auth story |
-| OpenHands | keep the client in observation mode first even though the skill submission is already filed | runtime readiness -> builder starter pack -> compare preview -> recovery or store cockpit reads | OpenHands/extensions submission is open; do not call it merged until the host accepts it |
+| OpenHands | keep the client in observation mode first even though the repo-owned skill packet already exists | runtime readiness -> builder starter pack -> compare preview -> recovery or store cockpit reads | `OpenHands/extensions#151` is currently closed and unmerged; do not call it an active accepted host surface |
 | OpenCode | treat DealWatch as a local product truth source, not as a hosted platform service | MCP discovery -> builder starter pack -> compare preview -> watch or group detail | ecosystem-listing candidate only, no first-party store claim |
-| OpenClaw | treat DealWatch as a local compare-first truth backend or workflow shell dependency, not as a runtime base | `get_runtime_readiness` -> `get_builder_starter_pack` -> `compare_preview` -> watch or group reads -> recovery or store cockpit reads | the ClawHub skill is live, but the safe first flow still starts from the same local read-only runtime |
+| OpenClaw | treat DealWatch as a local compare-first truth backend or workflow shell dependency, not as a runtime base | `get_runtime_readiness` -> `get_builder_starter_pack` -> `compare_preview` -> watch or group reads -> recovery or store cockpit reads | ClawHub is still the intended public host surface, but current public search/API evidence is not strong enough to claim a live listing |
 
 Use the recipe ledger when you need the next level of honesty:
 
@@ -186,9 +186,9 @@ ships in-repo today, and what we still must **not** claim.
 | Claude Code | official marketplace + custom marketplaces | [`plugins/dealwatch-builder-pack/.claude-plugin/plugin.json`](../../plugins/dealwatch-builder-pack/.claude-plugin/plugin.json), [`.claude-plugin/marketplace.json`](../../.claude-plugin/marketplace.json) | marketplace-submission candidate, **not officially listed** |
 | Codex | Plugin Directory + repo/personal marketplace | [`plugins/dealwatch-builder-pack/.codex-plugin/plugin.json`](../../plugins/dealwatch-builder-pack/.codex-plugin/plugin.json), [`../../marketplace.json`](../../marketplace.json) | Plugin Directory candidate, **not officially listed** |
 | Cline | MCP Marketplace issue intake | [`../../llms-install.md`](../../llms-install.md), [`../../assets/marketplace/dealwatch-cline-logo-400.png`](../../assets/marketplace/dealwatch-cline-logo-400.png) | marketplace-submission candidate, **not officially listed** |
-| OpenHands | global skill registry | [`./skills/openhands-readonly-builder-skill.md`](./skills/openhands-readonly-builder-skill.md) | active submission is [`OpenHands/extensions#151`](https://github.com/OpenHands/extensions/pull/151) with maintainer-requested changes; [`#152`](https://github.com/OpenHands/extensions/pull/152) is the retired predecessor |
+| OpenHands | global skill registry | [`./skills/openhands-readonly-builder-skill.md`](./skills/openhands-readonly-builder-skill.md) | `OpenHands/extensions#151` is closed and unmerged after maintainer-requested changes; [`#152`](https://github.com/OpenHands/extensions/pull/152) is the retired predecessor |
 | OpenCode | ecosystem listing | [`./recipes/opencode.md`](./recipes/opencode.md), [`./examples/opencode.jsonc`](./examples/opencode.jsonc) | ecosystem-listing candidate, **not officially listed** |
-| OpenClaw | ClawHub public registry | [`./recipes/openclaw.md`](./recipes/openclaw.md), [`./skills/openclaw-readonly-builder-skill.md`](./skills/openclaw-readonly-builder-skill.md), compatible bundle assets under [`plugins/dealwatch-builder-pack/`](../../plugins/dealwatch-builder-pack/) | live on ClawHub as `dealwatch-readonly-builder` |
+| OpenClaw | ClawHub public registry | [`./recipes/openclaw.md`](./recipes/openclaw.md), [`./skills/openclaw-readonly-builder-skill.md`](./skills/openclaw-readonly-builder-skill.md), compatible bundle assets under [`plugins/dealwatch-builder-pack/`](../../plugins/dealwatch-builder-pack/) | repo-owned OpenClaw cargo is ready, but current public ClawHub search/API evidence is not strong enough to claim a live listing |
 
 ## Official MCP Registry reality
 
@@ -217,7 +217,7 @@ DealWatch now has both halves of the MCP story: the product side and the registr
 That means the remaining stop line is no longer “publish the first package.”
 It is:
 
-- keep the active OpenHands line on `#151` until the host accepts it, while treating `#152` as a retired predecessor
+- if the OpenHands lane matters, restart from the closed state of `#151` rather than pretending it is still an active host review queue
 - wait for directory-style host reviews such as MCP.so
 - decide which additional first-party host surfaces deserve a live listing beyond the current local-first boundary
 
@@ -311,9 +311,9 @@ The honest current shape is still local-first:
 Not every client has a native package today:
 
 - Claude Code and Codex now have repo-owned native bundle artifacts
-- OpenHands now has an active submission in `OpenHands/extensions#151`, but it is still waiting on host acceptance after requested changes; `#152` is a retired predecessor
+- OpenHands `#151` is now closed and unmerged after requested changes; `#152` is a retired predecessor
 - OpenCode remains an ecosystem-listing candidate
-- OpenClaw now has a live ClawHub skill backed by the same compatible bundle assets and repo-native docs
+- OpenClaw still has repo-owned cargo and the intended ClawHub host surface, but this repo no longer claims fresh public live-listing proof
 
 Those artifacts still live in the repo as builder material first, but they no longer all stop at “candidate” status.
 

--- a/docs/integrations/config-recipes.md
+++ b/docs/integrations/config-recipes.md
@@ -84,4 +84,4 @@ These recipes do **not** mean:
 - write-side MCP is ready
 - DealWatch runs on Claude Code, Codex, OpenHands, OpenCode, or OpenClaw
 
-The honest reading is smaller: DealWatch now has a mixed state. PyPI, the Official MCP Registry, and the ClawHub skill are live; the OpenHands/extensions and MCP.so submissions are filed; Claude Code, Codex, OpenCode, and the Chrome Web Store still remain repo-owned or pending rather than first-party live listings.
+The honest reading is smaller: DealWatch now has a mixed state. PyPI and the Official MCP Registry are live; OpenClaw still lacks fresh public ClawHub listing proof; OpenHands `#151` is closed and unmerged; MCP.so is filed but not publicly listed; Claude Code, Codex, OpenCode, and the Chrome Web Store still remain repo-owned or pending rather than first-party live listings.

--- a/docs/integrations/examples/cli-builder-client-configs.response.json
+++ b/docs/integrations/examples/cli-builder-client-configs.response.json
@@ -147,14 +147,14 @@
         "Do not assume hosted multi-tenant auth exists.",
         "Do not expose recommendation as a builder feature."
       ],
-      "plugin_status": "Repo-owned OpenHands skill pack. The active host line is OpenHands/extensions PR #151, which still has maintainer-requested changes; treat PR #152 as the retired predecessor, not the current listing lane.",
+      "plugin_status": "Repo-owned OpenHands skill pack. OpenHands/extensions PR #151 is now closed, unmerged, and left with maintainer-requested changes; treat it as not-accepted host evidence, and treat PR #152 as the retired predecessor.",
       "distribution_surface_kind": "official_skill_registry",
       "official_public_surface": {
         "label": "OpenHands global skill registry",
         "url": "https://docs.openhands.dev/overview/skills/public"
       },
-      "distribution_candidate": "submission_done_platform_not_accepted_yet",
-      "listing_status": "submission_done_platform_not_accepted_yet",
+      "distribution_candidate": "closed_unmerged_host_changes_requested",
+      "listing_status": "closed_unmerged_not_accepted",
       "repo_distribution_artifacts": [
         "docs/integrations/skills/openhands-readonly-builder-skill.md",
         "docs/integrations/prompts/openhands-starter.md",
@@ -259,14 +259,14 @@
         "Do not assume write-side MCP or operator automation is ready.",
         "Do not treat local-first proof surfaces as hosted control plane guarantees."
       ],
-      "plugin_status": "Repo-owned OpenClaw skill is live on ClawHub as dealwatch-readonly-builder. The official public surface is ClawHub, but the runtime story still stays local-first and read-only.",
+      "plugin_status": "Repo-owned OpenClaw skill packet exists, but current public ClawHub search/API does not provide fresh listing proof for dealwatch-readonly-builder. Treat ClawHub as the intended host surface, not as confirmed live listing proof.",
       "distribution_surface_kind": "clawhub_public_registry",
       "official_public_surface": {
         "label": "OpenClaw ClawHub registry",
         "url": "https://docs.openclaw.ai/tools/clawhub"
       },
-      "distribution_candidate": "clawhub_live",
-      "listing_status": "live_on_clawhub",
+      "distribution_candidate": "repo_owned_skill_candidate",
+      "listing_status": "no_fresh_public_evidence",
       "repo_distribution_artifacts": [
         "docs/integrations/prompts/openclaw-starter.md",
         "docs/integrations/skills/openclaw-readonly-builder-skill.md",

--- a/docs/integrations/examples/http-builder-client-configs.response.json
+++ b/docs/integrations/examples/http-builder-client-configs.response.json
@@ -147,14 +147,14 @@
         "Do not assume hosted multi-tenant auth exists.",
         "Do not expose recommendation as a builder feature."
       ],
-      "plugin_status": "Repo-owned OpenHands skill pack. The active host line is OpenHands/extensions PR #151, which still has maintainer-requested changes; treat PR #152 as the retired predecessor, not the current listing lane.",
+      "plugin_status": "Repo-owned OpenHands skill pack. OpenHands/extensions PR #151 is now closed, unmerged, and left with maintainer-requested changes; treat it as not-accepted host evidence, and treat PR #152 as the retired predecessor.",
       "distribution_surface_kind": "official_skill_registry",
       "official_public_surface": {
         "label": "OpenHands global skill registry",
         "url": "https://docs.openhands.dev/overview/skills/public"
       },
-      "distribution_candidate": "submission_done_platform_not_accepted_yet",
-      "listing_status": "submission_done_platform_not_accepted_yet",
+      "distribution_candidate": "closed_unmerged_host_changes_requested",
+      "listing_status": "closed_unmerged_not_accepted",
       "repo_distribution_artifacts": [
         "docs/integrations/skills/openhands-readonly-builder-skill.md",
         "docs/integrations/prompts/openhands-starter.md",
@@ -259,14 +259,14 @@
         "Do not assume write-side MCP or operator automation is ready.",
         "Do not treat local-first proof surfaces as hosted control plane guarantees."
       ],
-      "plugin_status": "Repo-owned OpenClaw skill is live on ClawHub as dealwatch-readonly-builder. The official public surface is ClawHub, but the runtime story still stays local-first and read-only.",
+      "plugin_status": "Repo-owned OpenClaw skill packet exists, but current public ClawHub search/API does not provide fresh listing proof for dealwatch-readonly-builder. Treat ClawHub as the intended host surface, not as confirmed live listing proof.",
       "distribution_surface_kind": "clawhub_public_registry",
       "official_public_surface": {
         "label": "OpenClaw ClawHub registry",
         "url": "https://docs.openclaw.ai/tools/clawhub"
       },
-      "distribution_candidate": "clawhub_live",
-      "listing_status": "live_on_clawhub",
+      "distribution_candidate": "repo_owned_skill_candidate",
+      "listing_status": "no_fresh_public_evidence",
       "repo_distribution_artifacts": [
         "docs/integrations/prompts/openclaw-starter.md",
         "docs/integrations/skills/openclaw-readonly-builder-skill.md",

--- a/docs/integrations/examples/mcp-client-starters.response.json
+++ b/docs/integrations/examples/mcp-client-starters.response.json
@@ -101,14 +101,14 @@
     "distribution_surface_kind": "official_skill_registry",
     "official_public_surface_label": "OpenHands global skill registry",
     "official_public_surface_url": "https://docs.openhands.dev/overview/skills/public",
-    "distribution_candidate": "submission_done_platform_not_accepted_yet",
-    "listing_status": "submission_done_platform_not_accepted_yet",
+    "distribution_candidate": "closed_unmerged_host_changes_requested",
+    "listing_status": "closed_unmerged_not_accepted",
     "repo_distribution_artifacts": [
       "docs/integrations/skills/openhands-readonly-builder-skill.md",
       "docs/integrations/prompts/openhands-starter.md",
       "docs/integrations/recipes/openhands.md"
     ],
-    "plugin_status": "Repo-owned OpenHands skill pack. The active host line is OpenHands/extensions PR #151, which still has maintainer-requested changes; treat PR #152 as the retired predecessor, not the current listing lane.",
+    "plugin_status": "Repo-owned OpenHands skill pack. OpenHands/extensions PR #151 is now closed, unmerged, and left with maintainer-requested changes; treat it as not-accepted host evidence, and treat PR #152 as the retired predecessor.",
     "boundary_reminders": [
       "Do not assume destructive automation is safe.",
       "Do not assume hosted multi-tenant auth exists.",
@@ -177,8 +177,8 @@
     "distribution_surface_kind": "clawhub_public_registry",
     "official_public_surface_label": "OpenClaw ClawHub registry",
     "official_public_surface_url": "https://docs.openclaw.ai/tools/clawhub",
-    "distribution_candidate": "clawhub_live",
-    "listing_status": "live_on_clawhub",
+    "distribution_candidate": "repo_owned_skill_candidate",
+    "listing_status": "no_fresh_public_evidence",
     "repo_distribution_artifacts": [
       "docs/integrations/prompts/openclaw-starter.md",
       "docs/integrations/skills/openclaw-readonly-builder-skill.md",
@@ -186,7 +186,7 @@
       "plugins/dealwatch-builder-pack/.claude-plugin/plugin.json",
       "plugins/dealwatch-builder-pack/.codex-plugin/plugin.json"
     ],
-    "plugin_status": "Repo-owned OpenClaw skill is live on ClawHub as dealwatch-readonly-builder. The official public surface is ClawHub, but the runtime story still stays local-first and read-only.",
+    "plugin_status": "Repo-owned OpenClaw skill packet exists, but current public ClawHub search/API does not provide fresh listing proof for dealwatch-readonly-builder. Treat ClawHub as the intended host surface, not as confirmed live listing proof.",
     "boundary_reminders": [
       "Do not treat DealWatch as an OpenClaw runtime base.",
       "Do not assume write-side MCP or operator automation is ready.",

--- a/public-skills/dealwatch-readonly-builder/manifest.yaml
+++ b/public-skills/dealwatch-readonly-builder/manifest.yaml
@@ -1,7 +1,6 @@
 schema_version: 1
 name: dealwatch-readonly-builder
 display_name: DealWatch Read-only Builder
-version: 1.0.0
 version: 1.1.0
 summary: >
   Public skill bundle for DealWatch that packages MCP install guidance, a
@@ -20,7 +19,7 @@ compatibility:
     published_listing: false
   clawhub:
     mode: skill publish plus published MCP config
-    published_listing: true
+    published_listing: false
 capabilities:
   - install the published DealWatch MCP package in host-specific config
   - expose the stable read-only DealWatch tool inventory
@@ -30,9 +29,9 @@ boundaries:
   hosted_operator: false
   write_capable_mcp: false
   oauth_login: false
-  official_listing_live: true
+  official_listing_live: false
 distribution_notes:
-  current_claim: ClawHub listing is live; other hosts should only claim submission or live state when independently confirmed.
+  current_claim: No fresh public ClawHub listing proof is currently available; other hosts should only claim submission or live state when independently confirmed.
 verification:
   repo_commands:
     - python3 scripts/verify_public_surface.py

--- a/site/builders.html
+++ b/site/builders.html
@@ -79,7 +79,7 @@
             <a class="button-secondary" href="https://github.com/xiaojiou176-open/dealwatch/blob/main/docs/roadmaps/dealwatch-api-mcp-substrate-phase1.md" data-i18n="site.buildersPage.heroContractCta">Read the phase-1 contract</a>
             <a class="button-secondary" href="./data/builder-client-catalog.json" data-i18n="site.buildersPage.heroSecondaryCta">Open the client catalog</a>
           </div>
-          <p class="small-note" data-i18n="site.buildersPage.heroNote">Human path first: builder pack, contract, then runtime. If you still need the product pitch or the evidence trail, go back to Compare Preview and Proof first. Native Claude/Codex bundle candidates and listing-prep inputs only come after the route is clear. Public proof is intentionally mixed: PyPI, the Official MCP Registry, and OpenClaw's ClawHub skill are live, while OpenHands and MCP.so still wait on host acceptance.</p>
+          <p class="small-note" data-i18n="site.buildersPage.heroNote">Human path first: builder pack, contract, then runtime. If you still need the product pitch or the evidence trail, go back to Compare Preview and Proof first. Native Claude/Codex bundle candidates and listing-prep inputs only come after the route is clear. Public proof is intentionally mixed: PyPI and the Official MCP Registry are live, while OpenClaw still lacks fresh public ClawHub listing proof, OpenHands is closed and unmerged, and MCP.so still waits on host acceptance.</p>
           <p class="small-note" data-i18n="site.buildersPage.jumpSummary">Both paths still stop at the same read-only, local-first boundary. No hosted control plane, no write-side MCP promise, and no claim that every host listing is already live.</p>
           <div class="micro-links">
             <a href="./data/builder-client-catalog.json" data-i18n="site.buildersPage.catalogLink">Static client catalog JSON</a>
@@ -309,7 +309,7 @@ PYTHONPATH=src uv run python -m dealwatch.mcp serve --transport stdio</pre>
           </div>
           <div class="card">
             <h3 data-i18n="site.buildersPage.distributionMarketplaceTitle">Native bundle candidates</h3>
-            <p data-i18n="site.buildersPage.distributionMarketplaceSummary">Claude Code and Codex now also have repo-owned native bundle artifacts in the shared builder pack. OpenHands is active on `OpenHands/extensions#151` with maintainer-requested changes, `#152` is the retired predecessor, OpenCode remains an ecosystem-listing candidate, and OpenClaw is live on ClawHub.</p>
+            <p data-i18n="site.buildersPage.distributionMarketplaceSummary">Claude Code and Codex now also have repo-owned native bundle artifacts in the shared builder pack. OpenHands `#151` is closed and unmerged, `#152` is the retired predecessor, OpenCode remains an ecosystem-listing candidate, and OpenClaw still lacks fresh public ClawHub listing proof.</p>
             <div class="cta-row">
               <a class="button-secondary" href="https://github.com/xiaojiou176-open/dealwatch/tree/main/plugins/dealwatch-builder-pack" data-i18n="site.buildersPage.distributionSocialCta">Open the shared bundle</a>
               <a class="button-secondary" href="https://github.com/xiaojiou176-open/dealwatch/blob/main/docs/integrations/README.md#official-distribution-reality-by-client" data-i18n="site.buildersPage.distributionProofCta">Open the distribution matrix</a>
@@ -347,7 +347,7 @@ PYTHONPATH=src uv run python -m dealwatch.mcp serve --transport stdio</pre>
         <div class="faq-grid">
           <div class="faq-item">
             <h3 data-i18n="site.buildersPage.boundaryPluginTitle">Bundle candidates, not official listings</h3>
-            <p data-i18n="site.buildersPage.boundaryPluginSummary">DealWatch now ships repo-owned builder-pack materials for every client, native bundle candidates for Claude Code and Codex, and listing-prep inputs for the broader ecosystem. Some public proof is already live (PyPI, the Official MCP Registry, and OpenClaw's ClawHub skill), while OpenHands and MCP.so are still submitted but not yet accepted, and the Chrome companion remains not published.</p>
+            <p data-i18n="site.buildersPage.boundaryPluginSummary">DealWatch now ships repo-owned builder-pack materials for every client, native bundle candidates for Claude Code and Codex, and listing-prep inputs for the broader ecosystem. Some public proof is already live (PyPI and the Official MCP Registry), while OpenClaw still lacks fresh public ClawHub listing proof, OpenHands is closed and unmerged, MCP.so is still not publicly accepted, and the Chrome companion remains not published.</p>
           </div>
           <div class="faq-item">
             <h3 data-i18n="site.buildersPage.boundaryHostedTitle">No hosted control plane</h3>

--- a/site/data/builder-client-catalog.json
+++ b/site/data/builder-client-catalog.json
@@ -161,14 +161,14 @@
         "get_recovery_inbox",
         "get_store_onboarding_cockpit"
       ],
-      "plugin_status": "Repo-owned OpenHands skill pack. The active host line is OpenHands/extensions PR #151, which still has maintainer-requested changes; treat PR #152 as the retired predecessor, not the current listing lane.",
+      "plugin_status": "Repo-owned OpenHands skill pack. OpenHands/extensions PR #151 is now closed, unmerged, and left with maintainer-requested changes; treat it as not-accepted host evidence, and treat PR #152 as the retired predecessor.",
       "distribution_surface_kind": "official_skill_registry",
       "official_public_surface": {
         "label": "OpenHands global skill registry",
         "url": "https://docs.openhands.dev/overview/skills/public"
       },
-      "distribution_candidate": "submission_done_platform_not_accepted_yet",
-      "listing_status": "submission_done_platform_not_accepted_yet",
+      "distribution_candidate": "closed_unmerged_host_changes_requested",
+      "listing_status": "closed_unmerged_not_accepted",
       "repo_distribution_artifacts": [
         "docs/integrations/skills/openhands-readonly-builder-skill.md",
         "docs/integrations/prompts/openhands-starter.md",
@@ -277,14 +277,14 @@
         "get_recovery_inbox",
         "get_store_onboarding_cockpit"
       ],
-      "plugin_status": "Repo-owned OpenClaw skill is live on ClawHub as dealwatch-readonly-builder. The official public surface is ClawHub, but the runtime story still stays local-first and read-only.",
+      "plugin_status": "Repo-owned OpenClaw skill packet exists, but current public ClawHub search/API does not provide fresh listing proof for dealwatch-readonly-builder. Treat ClawHub as the intended host surface, not as confirmed live listing proof.",
       "distribution_surface_kind": "clawhub_public_registry",
       "official_public_surface": {
         "label": "OpenClaw ClawHub registry",
         "url": "https://docs.openclaw.ai/tools/clawhub"
       },
-      "distribution_candidate": "clawhub_live",
-      "listing_status": "live_on_clawhub",
+      "distribution_candidate": "repo_owned_skill_candidate",
+      "listing_status": "no_fresh_public_evidence",
       "repo_distribution_artifacts": [
         "docs/integrations/prompts/openclaw-starter.md",
         "docs/integrations/skills/openclaw-readonly-builder-skill.md",

--- a/site/data/builder-client-configs.json
+++ b/site/data/builder-client-configs.json
@@ -155,14 +155,14 @@
         "Do not assume hosted multi-tenant auth exists.",
         "Do not expose recommendation as a builder feature."
       ],
-      "plugin_status": "Repo-owned OpenHands skill pack. The active host line is OpenHands/extensions PR #151, which still has maintainer-requested changes; treat PR #152 as the retired predecessor, not the current listing lane.",
+      "plugin_status": "Repo-owned OpenHands skill pack. OpenHands/extensions PR #151 is now closed, unmerged, and left with maintainer-requested changes; treat it as not-accepted host evidence, and treat PR #152 as the retired predecessor.",
       "distribution_surface_kind": "official_skill_registry",
       "official_public_surface": {
         "label": "OpenHands global skill registry",
         "url": "https://docs.openhands.dev/overview/skills/public"
       },
-      "distribution_candidate": "submission_done_platform_not_accepted_yet",
-      "listing_status": "submission_done_platform_not_accepted_yet",
+      "distribution_candidate": "closed_unmerged_host_changes_requested",
+      "listing_status": "closed_unmerged_not_accepted",
       "repo_distribution_artifacts": [
         "docs/integrations/skills/openhands-readonly-builder-skill.md",
         "docs/integrations/prompts/openhands-starter.md",
@@ -275,14 +275,14 @@
         "Do not assume write-side MCP or operator automation is ready.",
         "Do not treat local-first proof surfaces as hosted control plane guarantees."
       ],
-      "plugin_status": "Repo-owned OpenClaw skill is live on ClawHub as dealwatch-readonly-builder. The official public surface is ClawHub, but the runtime story still stays local-first and read-only.",
+      "plugin_status": "Repo-owned OpenClaw skill packet exists, but current public ClawHub search/API does not provide fresh listing proof for dealwatch-readonly-builder. Treat ClawHub as the intended host surface, not as confirmed live listing proof.",
       "distribution_surface_kind": "clawhub_public_registry",
       "official_public_surface": {
         "label": "OpenClaw ClawHub registry",
         "url": "https://docs.openclaw.ai/tools/clawhub"
       },
-      "distribution_candidate": "clawhub_live",
-      "listing_status": "live_on_clawhub",
+      "distribution_candidate": "repo_owned_skill_candidate",
+      "listing_status": "no_fresh_public_evidence",
       "repo_distribution_artifacts": [
         "docs/integrations/prompts/openclaw-starter.md",
         "docs/integrations/skills/openclaw-readonly-builder-skill.md",

--- a/site/data/builder-client-starters.json
+++ b/site/data/builder-client-starters.json
@@ -157,14 +157,14 @@
         "get_recovery_inbox",
         "get_store_onboarding_cockpit"
       ],
-      "plugin_status": "Repo-owned OpenHands skill pack. The active host line is OpenHands/extensions PR #151, which still has maintainer-requested changes; treat PR #152 as the retired predecessor, not the current listing lane.",
+      "plugin_status": "Repo-owned OpenHands skill pack. OpenHands/extensions PR #151 is now closed, unmerged, and left with maintainer-requested changes; treat it as not-accepted host evidence, and treat PR #152 as the retired predecessor.",
       "distribution_surface_kind": "official_skill_registry",
       "official_public_surface": {
         "label": "OpenHands global skill registry",
         "url": "https://docs.openhands.dev/overview/skills/public"
       },
-      "distribution_candidate": "submission_done_platform_not_accepted_yet",
-      "listing_status": "submission_done_platform_not_accepted_yet",
+      "distribution_candidate": "closed_unmerged_host_changes_requested",
+      "listing_status": "closed_unmerged_not_accepted",
       "repo_distribution_artifacts": [
         "docs/integrations/skills/openhands-readonly-builder-skill.md",
         "docs/integrations/prompts/openhands-starter.md",
@@ -263,14 +263,14 @@
         "get_recovery_inbox",
         "get_store_onboarding_cockpit"
       ],
-      "plugin_status": "Repo-owned OpenClaw skill is live on ClawHub as dealwatch-readonly-builder. The official public surface is ClawHub, but the runtime story still stays local-first and read-only.",
+      "plugin_status": "Repo-owned OpenClaw skill packet exists, but current public ClawHub search/API does not provide fresh listing proof for dealwatch-readonly-builder. Treat ClawHub as the intended host surface, not as confirmed live listing proof.",
       "distribution_surface_kind": "clawhub_public_registry",
       "official_public_surface": {
         "label": "OpenClaw ClawHub registry",
         "url": "https://docs.openclaw.ai/tools/clawhub"
       },
-      "distribution_candidate": "clawhub_live",
-      "listing_status": "live_on_clawhub",
+      "distribution_candidate": "repo_owned_skill_candidate",
+      "listing_status": "no_fresh_public_evidence",
       "repo_distribution_artifacts": [
         "docs/integrations/prompts/openclaw-starter.md",
         "docs/integrations/skills/openclaw-readonly-builder-skill.md",

--- a/site/data/i18n/en.json
+++ b/site/data/i18n/en.json
@@ -68,17 +68,17 @@
       "title": "Inspect cross-store URL candidates before you create a task or group",
       "summary": "Start small: paste the candidate URLs, let DealWatch normalize the basket, then use the decision board to decide whether this should stay in review, become one task, or become a compare-aware group.",
       "zipCode": "ZIP Code",
-    "productUrls": "Product URLs",
-    "productUrlsHelp": "Use one URL per line. The compare preview accepts 2 to 10 non-empty URLs.",
-    "loading": "Comparing product URLs...",
-    "submit": "Compare URLs",
-    "errors": {
-      "zipRequired": "ZIP code is required.",
-      "invalidProductUrl": "Each line must be a valid product URL.",
-      "minUrls": "Enter at least two product URLs.",
-      "maxUrls": "Enter no more than ten product URLs."
-    }
-  },
+      "productUrls": "Product URLs",
+      "productUrlsHelp": "Use one URL per line. The compare preview accepts 2 to 10 non-empty URLs.",
+      "loading": "Comparing product URLs...",
+      "submit": "Compare URLs",
+      "errors": {
+        "zipRequired": "ZIP code is required.",
+        "invalidProductUrl": "Each line must be a valid product URL.",
+        "minUrls": "Enter at least two product URLs.",
+        "maxUrls": "Enter no more than ten product URLs."
+      }
+    },
     "route": {
       "eyebrow": "First-success path",
       "title": "Keep the first screen about one decision, not six doors",
@@ -177,55 +177,55 @@
         "hold": "hold",
         "info": "info"
       },
-    "stats": {
-      "resolved": "Resolved",
-      "groupReady": "Group-ready",
-      "bestListed": "Best listed",
-      "strongestPair": "Strongest pair",
-      "aiTitle": "AI-assisted explanation",
-      "aiNote": "The deterministic decision board stays primary. This card is only the explain layer on top of that evidence.",
-      "riskNotes": "{{count}} note{{plural}}",
-      "unsupported": "Unsupported",
-      "fetchFailures": "Fetch failures"
-    },
-    "ai": {
-      "badge": {
-        "ok": "available",
-        "disabled": "disabled",
-        "error": "error",
-        "skipped": "skipped",
-        "unavailable": "unavailable"
+      "stats": {
+        "resolved": "Resolved",
+        "groupReady": "Group-ready",
+        "bestListed": "Best listed",
+        "strongestPair": "Strongest pair",
+        "aiTitle": "AI-assisted explanation",
+        "aiNote": "The deterministic decision board stays primary. This card is only the explain layer on top of that evidence.",
+        "riskNotes": "{{count}} note{{plural}}",
+        "unsupported": "Unsupported",
+        "fetchFailures": "Fetch failures"
       },
-      "headline": {
-        "ok": "AI-assisted explanation",
-        "disabled": "AI assistance is disabled",
-        "error": "AI-assisted explanation hit an error",
-        "skipped": "AI-assisted explanation was skipped",
-        "unavailable": "AI-assisted explanation unavailable"
+      "ai": {
+        "badge": {
+          "ok": "available",
+          "disabled": "disabled",
+          "error": "error",
+          "skipped": "skipped",
+          "unavailable": "unavailable"
+        },
+        "headline": {
+          "ok": "AI-assisted explanation",
+          "disabled": "AI assistance is disabled",
+          "error": "AI-assisted explanation hit an error",
+          "skipped": "AI-assisted explanation was skipped",
+          "unavailable": "AI-assisted explanation unavailable"
+        },
+        "summary": {
+          "disabled": "AI assistance is disabled for this workspace. The decision board, risk summary, and pair evidence remain the source of truth.",
+          "error": "AI-assisted explanation could not be generated for this compare run. Review the deterministic summary and pair evidence instead.",
+          "skipped": "AI-assisted explanation was skipped for this compare run. The deterministic summary and pair evidence still tell the full story.",
+          "unavailable": "AI-assisted explanation unavailable. Showing deterministic summary and evidence only."
+        }
       },
-      "summary": {
-        "disabled": "AI assistance is disabled for this workspace. The decision board, risk summary, and pair evidence remain the source of truth.",
-        "error": "AI-assisted explanation could not be generated for this compare run. Review the deterministic summary and pair evidence instead.",
-        "skipped": "AI-assisted explanation was skipped for this compare run. The deterministic summary and pair evidence still tell the full story.",
-        "unavailable": "AI-assisted explanation unavailable. Showing deterministic summary and evidence only."
+      "recommendation": {
+        "eyebrow": "Recommendation",
+        "basisTitle": "Basis",
+        "uncertaintyTitle": "Uncertainty",
+        "evidenceRefsTitle": "Evidence refs",
+        "whyAbstained": "Why this recommendation abstained",
+        "verdict": {
+          "wait": "Keep watching",
+          "recheck_later": "Re-check later",
+          "insufficient_evidence": "Not enough evidence yet"
+        }
       }
     },
-    "recommendation": {
-      "eyebrow": "Recommendation",
-      "basisTitle": "Basis",
-      "uncertaintyTitle": "Uncertainty",
-      "evidenceRefsTitle": "Evidence refs",
-      "whyAbstained": "Why this recommendation abstained",
-      "verdict": {
-        "wait": "Keep watching",
-        "recheck_later": "Re-check later",
-        "insufficient_evidence": "Not enough evidence yet"
-      }
-    }
-  },
-  "saved": {
-    "labelWithTitle": "{{title}} · ZIP {{zipCode}}",
-    "labelFallback": "Compare evidence · ZIP {{zipCode}}",
+    "saved": {
+      "labelWithTitle": "{{title}} · ZIP {{zipCode}}",
+      "labelFallback": "Compare evidence · ZIP {{zipCode}}",
       "shareTitle": "DealWatch compare evidence package",
       "shareLabel": "Label: {{value}}",
       "shareSavedAt": "Saved at: {{value}}",
@@ -341,24 +341,24 @@
       "recipientEmail": "Recipient Email",
       "enableNotifications": "Enable notifications for this group",
       "rowsEnteringBasket": "Rows that will enter the basket",
-    "listedAtStore": "{{storeKey}} · listed {{value}}",
-    "similarity": "similarity {{value}}",
-    "noSuccessfulCandidates": "No successful compare candidates are available yet, so group creation stays locked.",
-    "lockedHint": "A compare-aware group stays locked until at least two successful candidates survive the preview. That keeps a thin basket from pretending it is durable compare truth.",
-    "creating": "Creating watch group from compare candidates...",
-    "createButton": "Create watch group from successful candidates",
-    "defaultTitleSuffix": "compare group",
-    "errors": {
-      "titleTooLong": "Group title must stay within 120 characters.",
-      "zipRequired": "ZIP code is required.",
-      "cadenceMin": "Cadence must be at least 5 minutes.",
-      "cadenceMax": "Cadence must stay within 10080 minutes.",
-      "thresholdValueMin": "Threshold value must be zero or above.",
-      "cooldownMin": "Cooldown must be zero or above.",
-      "cooldownMax": "Cooldown must stay within 10080 minutes.",
-      "recipientEmailRequired": "Recipient email is required."
-    }
-  },
+      "listedAtStore": "{{storeKey}} · listed {{value}}",
+      "similarity": "similarity {{value}}",
+      "noSuccessfulCandidates": "No successful compare candidates are available yet, so group creation stays locked.",
+      "lockedHint": "A compare-aware group stays locked until at least two successful candidates survive the preview. That keeps a thin basket from pretending it is durable compare truth.",
+      "creating": "Creating watch group from compare candidates...",
+      "createButton": "Create watch group from successful candidates",
+      "defaultTitleSuffix": "compare group",
+      "errors": {
+        "titleTooLong": "Group title must stay within 120 characters.",
+        "zipRequired": "ZIP code is required.",
+        "cadenceMin": "Cadence must be at least 5 minutes.",
+        "cadenceMax": "Cadence must stay within 10080 minutes.",
+        "thresholdValueMin": "Threshold value must be zero or above.",
+        "cooldownMin": "Cooldown must be zero or above.",
+        "cooldownMax": "Cooldown must stay within 10080 minutes.",
+        "recipientEmailRequired": "Recipient email is required."
+      }
+    },
     "pairEvidence": {
       "title": "Pair evidence",
       "summary": "These scores are the pair-by-pair proof. They explain why two rows look close, and why a row might still stay out of the basket.",
@@ -1367,8 +1367,6 @@
       "mapTableSignal": "Signal",
       "mapTableWhere": "Where to look now",
       "mapTableWhy": "Why it is useful in public",
-      "evidenceMapTitle": "Evidence map",
-      "evidenceMapSummary": "Think of this as a map legend, not a scoreboard. It shows where each public claim should point when you want fresh proof without hard-coding counts into the page.",
       "evidenceMapTableSignal": "Signal",
       "evidenceMapTableWhere": "Where to look now",
       "evidenceMapTableWhy": "Why it is useful in public",
@@ -1606,7 +1604,7 @@
       "heroPackCta": "Open the builder pack",
       "heroSecondaryCta": "Open the client catalog",
       "heroContractCta": "Read the phase-1 contract",
-      "heroNote": "Human path first: builder pack, contract, then runtime. If you still need the product pitch or the evidence trail, go back to Compare Preview and Proof first. Native Claude/Codex bundle candidates and listing-prep inputs only come after the route is clear. Public proof is intentionally mixed: PyPI, the Official MCP Registry, and OpenClaw's ClawHub skill are live, while OpenHands and MCP.so still wait on host acceptance.",
+      "heroNote": "Human path first: builder pack, contract, then runtime. If you still need the product pitch or the evidence trail, go back to Compare Preview and Proof first. Native Claude/Codex bundle candidates and listing-prep inputs only come after the route is clear. Public proof is intentionally mixed: PyPI and the Official MCP Registry are live, while OpenClaw still lacks fresh public ClawHub listing proof, OpenHands is closed and unmerged, and MCP.so still waits on host acceptance.",
       "jumpSummary": "Both paths still stop at the same read-only, local-first boundary. No hosted control plane, no write-side MCP promise, and no claim that every host listing is already live.",
       "mirrorStartersLink": "Static client starters JSON",
       "mirrorPackLink": "Static starter pack JSON",
@@ -1666,7 +1664,7 @@
       "distributionPluginCta": "Open the builder pack docs",
       "distributionSkillCta": "Open the builder skill pack",
       "distributionMarketplaceTitle": "Native bundle candidates",
-      "distributionMarketplaceSummary": "Claude Code and Codex now also have repo-owned native bundle artifacts in the shared builder pack. OpenHands is active on `OpenHands/extensions#151` with maintainer-requested changes, `#152` is the retired predecessor, OpenCode remains an ecosystem-listing candidate, and OpenClaw is live on ClawHub.",
+      "distributionMarketplaceSummary": "Claude Code and Codex now also have repo-owned native bundle artifacts in the shared builder pack. OpenHands #151 is closed and unmerged, #152 is the retired predecessor, OpenCode remains an ecosystem-listing candidate, and OpenClaw still lacks fresh public ClawHub listing proof.",
       "distributionSocialCta": "Open the shared bundle",
       "distributionProofCta": "Open the distribution matrix",
       "distributionCatalogCta": "Open the client catalog",
@@ -1695,7 +1693,7 @@
       "boundaryTitle": "Boundary reminder",
       "boundarySummary": "A good builder frontdoor says both what to open next and what not to assume yet, so the page does not quietly turn into plugin theater.",
       "boundaryPluginTitle": "Bundle candidates, not official listings",
-      "boundaryPluginSummary": "DealWatch now ships repo-owned builder-pack materials for every client, native bundle candidates for Claude Code and Codex, and listing-prep inputs for the broader ecosystem. Some public proof is already live (PyPI, the Official MCP Registry, and OpenClaw's ClawHub skill), while OpenHands and MCP.so are still submitted but not yet accepted, and the Chrome companion remains not published.",
+      "boundaryPluginSummary": "DealWatch now ships repo-owned builder-pack materials for every client, native bundle candidates for Claude Code and Codex, and listing-prep inputs for the broader ecosystem. Some public proof is already live (PyPI and the Official MCP Registry), while OpenClaw still lacks fresh public ClawHub listing proof, OpenHands is closed and unmerged, MCP.so is still not publicly accepted, and the Chrome companion remains not published.",
       "boundaryHostedTitle": "No hosted control plane",
       "boundaryHostedSummary": "These builder paths are local-first. They do not prove a hosted remote control plane is live today.",
       "boundaryWriteTitle": "No write-side MCP promise",

--- a/site/data/i18n/zh-CN.json
+++ b/site/data/i18n/zh-CN.json
@@ -68,17 +68,17 @@
       "title": "先检查跨门店 URL 候选，再决定是否创建任务或分组",
       "summary": "先把候选 URL 贴进来，让 DealWatch 规范化这个篮子，再根据决策看板判断它该继续留在复核区、变成单任务，还是升级成 compare-aware group。",
       "zipCode": "邮编",
-    "productUrls": "商品链接",
-    "productUrlsHelp": "每行填写一个 URL。Compare Preview 接受 2 到 10 个非空链接。",
-    "loading": "正在比对商品链接...",
-    "submit": "开始比价",
-    "errors": {
-      "zipRequired": "邮编不能为空。",
-      "invalidProductUrl": "每一行都必须是有效的商品 URL。",
-      "minUrls": "至少输入两个商品 URL。",
-      "maxUrls": "最多输入十个商品 URL。"
-    }
-  },
+      "productUrls": "商品链接",
+      "productUrlsHelp": "每行填写一个 URL。Compare Preview 接受 2 到 10 个非空链接。",
+      "loading": "正在比对商品链接...",
+      "submit": "开始比价",
+      "errors": {
+        "zipRequired": "邮编不能为空。",
+        "invalidProductUrl": "每一行都必须是有效的商品 URL。",
+        "minUrls": "至少输入两个商品 URL。",
+        "maxUrls": "最多输入十个商品 URL。"
+      }
+    },
     "route": {
       "eyebrow": "首个成功路径",
       "title": "第一屏要围绕一个决策，而不是六扇门同时喊你",
@@ -177,55 +177,55 @@
         "hold": "暂缓",
         "info": "信息"
       },
-    "stats": {
-      "resolved": "已解析",
-      "groupReady": "可建组",
-      "bestListed": "最佳标价",
-      "strongestPair": "最强配对",
-      "aiTitle": "AI 辅助解释",
-      "aiNote": "确定性的决策看板仍然是主轴，这张卡片只是覆盖在证据之上的解释层。",
-      "riskNotes": "{{count}} 条说明",
-      "unsupported": "不支持",
-      "fetchFailures": "抓取失败"
-    },
-    "ai": {
-      "badge": {
-        "ok": "可用",
-        "disabled": "已关闭",
-        "error": "错误",
-        "skipped": "已跳过",
-        "unavailable": "不可用"
+      "stats": {
+        "resolved": "已解析",
+        "groupReady": "可建组",
+        "bestListed": "最佳标价",
+        "strongestPair": "最强配对",
+        "aiTitle": "AI 辅助解释",
+        "aiNote": "确定性的决策看板仍然是主轴，这张卡片只是覆盖在证据之上的解释层。",
+        "riskNotes": "{{count}} 条说明",
+        "unsupported": "不支持",
+        "fetchFailures": "抓取失败"
       },
-      "headline": {
-        "ok": "AI 辅助解释",
-        "disabled": "AI 辅助已关闭",
-        "error": "AI 辅助解释出错了",
-        "skipped": "AI 辅助解释已跳过",
-        "unavailable": "AI 辅助解释不可用"
+      "ai": {
+        "badge": {
+          "ok": "可用",
+          "disabled": "已关闭",
+          "error": "错误",
+          "skipped": "已跳过",
+          "unavailable": "不可用"
+        },
+        "headline": {
+          "ok": "AI 辅助解释",
+          "disabled": "AI 辅助已关闭",
+          "error": "AI 辅助解释出错了",
+          "skipped": "AI 辅助解释已跳过",
+          "unavailable": "AI 辅助解释不可用"
+        },
+        "summary": {
+          "disabled": "当前工作区没有启用 AI 辅助。决策看板、风险摘要和配对证据仍然是主真相来源。",
+          "error": "这次 compare 没能生成 AI 辅助解释。请改看确定性的摘要和配对证据。",
+          "skipped": "这次 compare 跳过了 AI 辅助解释，但确定性的摘要和配对证据仍然能讲完整个故事。",
+          "unavailable": "AI 辅助解释当前不可用，因此这里只显示确定性摘要和证据。"
+        }
       },
-      "summary": {
-        "disabled": "当前工作区没有启用 AI 辅助。决策看板、风险摘要和配对证据仍然是主真相来源。",
-        "error": "这次 compare 没能生成 AI 辅助解释。请改看确定性的摘要和配对证据。",
-        "skipped": "这次 compare 跳过了 AI 辅助解释，但确定性的摘要和配对证据仍然能讲完整个故事。",
-        "unavailable": "AI 辅助解释当前不可用，因此这里只显示确定性摘要和证据。"
+      "recommendation": {
+        "eyebrow": "Recommendation",
+        "basisTitle": "依据",
+        "uncertaintyTitle": "不确定项",
+        "evidenceRefsTitle": "证据引用",
+        "whyAbstained": "为什么这条 recommendation 选择 abstain",
+        "verdict": {
+          "wait": "继续观察",
+          "recheck_later": "稍后再看",
+          "insufficient_evidence": "证据还不够"
+        }
       }
     },
-    "recommendation": {
-      "eyebrow": "Recommendation",
-      "basisTitle": "依据",
-      "uncertaintyTitle": "不确定项",
-      "evidenceRefsTitle": "证据引用",
-      "whyAbstained": "为什么这条 recommendation 选择 abstain",
-      "verdict": {
-        "wait": "继续观察",
-        "recheck_later": "稍后再看",
-        "insufficient_evidence": "证据还不够"
-      }
-    }
-  },
-  "saved": {
-    "labelWithTitle": "{{title}} · 邮编 {{zipCode}}",
-    "labelFallback": "Compare 证据 · 邮编 {{zipCode}}",
+    "saved": {
+      "labelWithTitle": "{{title}} · 邮编 {{zipCode}}",
+      "labelFallback": "Compare 证据 · 邮编 {{zipCode}}",
       "shareTitle": "DealWatch compare 证据包",
       "shareLabel": "标签：{{value}}",
       "shareSavedAt": "保存于：{{value}}",
@@ -341,24 +341,24 @@
       "recipientEmail": "收件邮箱",
       "enableNotifications": "为这个分组启用通知",
       "rowsEnteringBasket": "将进入篮子的候选行",
-    "listedAtStore": "{{storeKey}} · 标价 {{value}}",
-    "similarity": "相似度 {{value}}",
-    "noSuccessfulCandidates": "当前还没有成功的 compare 候选，因此 group 创建入口继续锁定。",
-    "lockedHint": "只有当至少两个成功候选通过 preview 后，compare-aware group 才会解锁，避免一个过薄的篮子假装自己已经是可靠的 compare 真相。",
-    "creating": "正在从 compare 候选创建 watch group...",
-    "createButton": "从成功候选创建 watch group",
-    "defaultTitleSuffix": "对比分组",
-    "errors": {
-      "titleTooLong": "分组标题不能超过 120 个字符。",
-      "zipRequired": "邮编不能为空。",
-      "cadenceMin": "运行频率至少要 5 分钟。",
-      "cadenceMax": "运行频率不能超过 10080 分钟。",
-      "thresholdValueMin": "阈值必须大于等于 0。",
-      "cooldownMin": "冷却时间必须大于等于 0。",
-      "cooldownMax": "冷却时间不能超过 10080 分钟。",
-      "recipientEmailRequired": "收件邮箱不能为空。"
-    }
-  },
+      "listedAtStore": "{{storeKey}} · 标价 {{value}}",
+      "similarity": "相似度 {{value}}",
+      "noSuccessfulCandidates": "当前还没有成功的 compare 候选，因此 group 创建入口继续锁定。",
+      "lockedHint": "只有当至少两个成功候选通过 preview 后，compare-aware group 才会解锁，避免一个过薄的篮子假装自己已经是可靠的 compare 真相。",
+      "creating": "正在从 compare 候选创建 watch group...",
+      "createButton": "从成功候选创建 watch group",
+      "defaultTitleSuffix": "对比分组",
+      "errors": {
+        "titleTooLong": "分组标题不能超过 120 个字符。",
+        "zipRequired": "邮编不能为空。",
+        "cadenceMin": "运行频率至少要 5 分钟。",
+        "cadenceMax": "运行频率不能超过 10080 分钟。",
+        "thresholdValueMin": "阈值必须大于等于 0。",
+        "cooldownMin": "冷却时间必须大于等于 0。",
+        "cooldownMax": "冷却时间不能超过 10080 分钟。",
+        "recipientEmailRequired": "收件邮箱不能为空。"
+      }
+    },
     "pairEvidence": {
       "title": "配对证据",
       "summary": "这些分数是逐对的证据，它们解释为什么两行看起来接近，以及为什么某一行仍然可能不该进入篮子。",
@@ -1191,27 +1191,27 @@
       "eyebrow": "比价预览",
       "brandTagline": "AI 增强产品流程里最安全的第一步。",
       "heroKicker": "服务于 AI 辅助决策的 compare 证据",
-    "heroTitle": "先确认商品目标，再创建持久状态。",
+      "heroTitle": "先确认商品目标，再创建持久状态。",
       "heroSummary": "Compare Preview 存在，是因为普通价格追踪器默认你已经知道正确的商品 URL。DealWatch 会更早一步开始：先验证候选、跨门店比较、查看确定性证据与 AI 辅助解释，再决定这行是否值得进入 watch task，还是应该继续留在 compare-aware watch group 里。",
-    "schema": {
-      "@context": "https://schema.org",
-      "@type": "WebPage",
+      "schema": {
+        "@context": "https://schema.org",
+        "@type": "WebPage",
         "name": "DealWatch Compare Preview | 先 Compare，再进入跟踪",
         "url": "https://xiaojiou176-open.github.io/dealwatch/compare-preview.html",
         "description": "打开一个只读样例 Compare Preview，然后按你的目标选择 Quick Start、Proof 或 Builders：分别对应本地运行栈、验证链路和只读 agent 接线。",
         "keywords": "DealWatch Compare Preview, compare-first, 只读样例, Quick Start, Proof, Builders",
-      "isPartOf": {
-        "@type": "WebSite",
-        "name": "DealWatch",
-        "url": "https://xiaojiou176-open.github.io/dealwatch/"
-      },
+        "isPartOf": {
+          "@type": "WebSite",
+          "name": "DealWatch",
+          "url": "https://xiaojiou176-open.github.io/dealwatch/"
+        },
         "about": [
           "以 compare-first 为核心的商品 URL 验证",
           "确定性 compare 证据与 AI 辅助解释",
           "只读样例 compare 体验"
         ]
       },
-    "heroPrimaryCta": "试试样例 Compare Preview",
+      "heroPrimaryCta": "试试样例 Compare Preview",
       "heroSecondaryCta": "运行本地快速开始",
       "statusReadonlyTitle": "2 个 URL 输入，0 个持久写入",
       "statusReadonlySummary": "Compare Preview 会保持只读，直到你明确决定创建任务。",
@@ -1367,8 +1367,6 @@
       "mapTableSignal": "信号",
       "mapTableWhere": "现在该看哪里",
       "mapTableWhy": "为什么它适合放在公共表面",
-      "evidenceMapTitle": "证据地图",
-      "evidenceMapSummary": "把这里理解成图例，不是排行榜。它告诉你每条 public claim 现在该指向哪里找新鲜证据，而不是把一堆会过期的数字硬编码在页面里。",
       "evidenceMapTableSignal": "信号",
       "evidenceMapTableWhere": "现在该看哪里",
       "evidenceMapTableWhy": "为什么它适合放在公共表面",
@@ -1606,7 +1604,7 @@
       "heroPackCta": "打开 builder pack",
       "heroSecondaryCta": "打开客户端目录",
       "heroContractCta": "先读 phase-1 合同",
-      "heroNote": "先走 human path：builder pack、contract、runtime。如果你还需要先看产品故事或证据链，就先回到 Compare Preview 和 Proof。Claude/Codex 的 native bundle candidate 和 listing-prep inputs 都要等这条路线看清以后再看，而且它们也不代表已经有 official listing。",
+      "heroNote": "先走 human path：builder pack、contract、再到 runtime。如果你还没看明白产品故事或证据面，先回 Compare Preview 和 Proof。Claude/Codex 的 native bundle candidate 与 listing-prep 输入，应该在路线讲清后再用。当前公开证据是混合态：PyPI 和官方 MCP Registry 已 live，而 OpenClaw 还缺 fresh 的公开 ClawHub listing 证据，OpenHands 已关闭且未合并，MCP.so 仍在等待 host acceptance。",
       "jumpSummary": "这两条路径最后都停在同一条 read-only、local-first 边界上。没有 hosted control plane、没有 published listing，也没有 write-side MCP 承诺。",
       "mirrorStartersLink": "静态 client starters JSON",
       "mirrorPackLink": "静态 starter pack JSON",
@@ -1669,7 +1667,7 @@
       "distributionPluginCta": "打开 builder pack 文档",
       "distributionSkillCta": "打开 builder skill pack",
       "distributionMarketplaceTitle": "Native bundle candidates",
-      "distributionMarketplaceSummary": "Claude Code 和 Codex 现在也有了共享 builder pack 里的 repo-owned native bundle artifact。OpenHands 已经有 OpenHands/extensions 提交回执，OpenCode 仍然是 ecosystem-listing candidate，而 OpenClaw 现在已经有 live 的 ClawHub skill。",
+      "distributionMarketplaceSummary": "Claude Code 和 Codex 现在已有共享 builder pack 里的 repo-owned native bundle artifact。OpenHands #151 已关闭且未合并，#152 是 retired predecessor，OpenCode 仍是 ecosystem-listing candidate，而 OpenClaw 目前还缺 fresh 的公开 ClawHub listing 证据。",
       "distributionSocialCta": "打开共享 bundle",
       "distributionProofCta": "打开 distribution matrix",
       "distributionCatalogCta": "打开 client catalog",
@@ -1698,7 +1696,7 @@
       "boundaryTitle": "边界提醒",
       "boundarySummary": "好的 builder 前门不只告诉你下一步去哪，也要告诉你现在还不能脑补成什么，否则页面很容易长成 plugin theater。",
       "boundaryPluginTitle": "有 bundle candidate，但还不是 official listing",
-      "boundaryPluginSummary": "DealWatch 现在已经给所有 client 准备好了 repo-owned builder-pack 材料，也给 Claude Code 和 Codex 准备好了 native bundle candidate，并给更大生态准备了 listing-prep inputs。但这仍然不代表任何 official marketplace 或 registry listing 已经存在。",
+      "boundaryPluginSummary": "DealWatch 现在已经给所有 client 准备好了 repo-owned builder-pack 材料，也给 Claude Code 和 Codex 准备好了 native bundle candidate，并给更大生态准备了 listing-prep 输入。当前已经 live 的公开证据只有 PyPI 和官方 MCP Registry；OpenClaw 还缺 fresh 的公开 ClawHub listing 证据，OpenHands 已关闭且未合并，MCP.so 也还没有公开接受，而 Chrome companion 仍未发布。",
       "boundaryHostedTitle": "不是 hosted control plane",
       "boundaryHostedSummary": "这些 builder 路径都是 local-first 的，不代表 hosted remote control plane 已经 live。",
       "boundaryWriteTitle": "没有 write-side MCP 承诺",

--- a/site/llms.txt
+++ b/site/llms.txt
@@ -68,7 +68,7 @@
 - Not a hosted SaaS.
 - Not a generic chat bot or autonomous agent.
 - Not a broad or builder-facing buy / wait recommendation engine. The shipped recommendation surface is limited to the local Compare Preview runtime flow.
-- Not a hosted plugin runtime or a universally accepted client listing today. PyPI, the Official MCP Registry, and OpenClaw's ClawHub skill are already live public surfaces, while OpenHands `#151` and MCP.so `#1558` are still waiting on host acceptance and the Chrome companion remains not published.
+- Not a hosted plugin runtime or a universally accepted client listing today. PyPI and the Official MCP Registry are already live public surfaces, while OpenClaw still lacks fresh public ClawHub listing proof, OpenHands `#151` is closed and unmerged, MCP.so `#1558` is still waiting on host acceptance, and the Chrome companion remains not published.
 
 ## Trust surfaces
 

--- a/src/dealwatch/builder_contract.py
+++ b/src/dealwatch/builder_contract.py
@@ -118,8 +118,8 @@ _CLIENT_STARTER_SPECS: list[dict[str, Any]] = [
         "distribution_surface_kind": "official_skill_registry",
         "official_public_surface_label": "OpenHands global skill registry",
         "official_public_surface_url": "https://docs.openhands.dev/overview/skills/public",
-        "distribution_candidate": "submission_done_platform_not_accepted_yet",
-        "listing_status": "submission_done_platform_not_accepted_yet",
+        "distribution_candidate": "closed_unmerged_host_changes_requested",
+        "listing_status": "closed_unmerged_not_accepted",
         "repo_distribution_artifacts": [
             "docs/integrations/skills/openhands-readonly-builder-skill.md",
             "docs/integrations/prompts/openhands-starter.md",
@@ -127,8 +127,8 @@ _CLIENT_STARTER_SPECS: list[dict[str, Any]] = [
         ],
         "plugin_status": (
             "Repo-owned OpenHands skill pack. "
-            "The active host line is OpenHands/extensions PR #151, which still has maintainer-requested changes; "
-            "treat PR #152 as the retired predecessor, not the current listing lane."
+            "OpenHands/extensions PR #151 is now closed, unmerged, and left with maintainer-requested changes; "
+            "treat it as not-accepted host evidence, and treat PR #152 as the retired predecessor."
         ),
         "boundary_reminders": [
             "Do not assume destructive automation is safe.",
@@ -201,8 +201,8 @@ _CLIENT_STARTER_SPECS: list[dict[str, Any]] = [
         "distribution_surface_kind": "clawhub_public_registry",
         "official_public_surface_label": "OpenClaw ClawHub registry",
         "official_public_surface_url": "https://docs.openclaw.ai/tools/clawhub",
-        "distribution_candidate": "clawhub_live",
-        "listing_status": "live_on_clawhub",
+        "distribution_candidate": "repo_owned_skill_candidate",
+        "listing_status": "no_fresh_public_evidence",
         "repo_distribution_artifacts": [
             "docs/integrations/prompts/openclaw-starter.md",
             "docs/integrations/skills/openclaw-readonly-builder-skill.md",
@@ -211,8 +211,9 @@ _CLIENT_STARTER_SPECS: list[dict[str, Any]] = [
             "plugins/dealwatch-builder-pack/.codex-plugin/plugin.json",
         ],
         "plugin_status": (
-            "Repo-owned OpenClaw skill is live on ClawHub as dealwatch-readonly-builder. "
-            "The official public surface is ClawHub, but the runtime story still stays local-first and read-only."
+            "Repo-owned OpenClaw skill packet exists, but current public ClawHub search/API does not provide "
+            "fresh listing proof for dealwatch-readonly-builder. Treat ClawHub as the intended host surface, "
+            "not as confirmed live listing proof."
         ),
         "boundary_reminders": [
             "Do not treat DealWatch as an OpenClaw runtime base.",

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -194,7 +194,8 @@ def test_mcp_client_starters_include_openclaw_without_plugin_claim() -> None:
     assert starters["openclaw"]["config_wrapper_status"] == "official_wrapper_documented"
     assert "ClawHub" in starters["openclaw"]["plugin_status"]
     assert starters["openclaw"]["distribution_surface_kind"] == "clawhub_public_registry"
-    assert starters["openclaw"]["listing_status"] == "live_on_clawhub"
+    assert starters["openclaw"]["listing_status"] == "no_fresh_public_evidence"
+    assert "fresh listing proof" in starters["openclaw"]["plugin_status"]
 
 
 def test_mcp_client_starters_keep_platform_specific_distribution_wording() -> None:
@@ -214,9 +215,9 @@ def test_mcp_client_starters_keep_platform_specific_distribution_wording() -> No
     assert "ClawHub" in starters["openclaw"]["plugin_status"]
     assert starters["claude-code"]["listing_status"] == "not_officially_listed"
     assert starters["codex"]["listing_status"] == "not_officially_listed"
-    assert starters["openhands"]["listing_status"] == "submission_done_platform_not_accepted_yet"
+    assert starters["openhands"]["listing_status"] == "closed_unmerged_not_accepted"
     assert starters["opencode"]["listing_status"] == "not_officially_listed"
-    assert starters["openclaw"]["listing_status"] == "live_on_clawhub"
+    assert starters["openclaw"]["listing_status"] == "no_fresh_public_evidence"
 
 
 def test_mcp_client_starters_include_recipe_paths_and_wrapper_status() -> None:

--- a/tests/test_public_skill_manifest.py
+++ b/tests/test_public_skill_manifest.py
@@ -1,0 +1,15 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+
+def test_public_skill_manifest_has_single_version_key() -> None:
+    manifest = (
+        Path(__file__).resolve().parents[1]
+        / "public-skills"
+        / "dealwatch-readonly-builder"
+        / "manifest.yaml"
+    )
+    lines = manifest.read_text(encoding="utf-8").splitlines()
+    version_lines = [line for line in lines if line.startswith("version:")]
+    assert version_lines == ["version: 1.1.0"]


### PR DESCRIPTION
## Summary
- make external distribution/public-listing wording match fresh public evidence
- downgrade OpenClaw/ClawHub from live claim to no-fresh-public-evidence
- downgrade OpenHands #151 from active submission wording to closed/unmerged wording
- add a manifest regression test and sync generated builder snapshots

## Verification
- ./scripts/test.sh -q
- pre-commit run --all-files
- python3 scripts/verify_builder_contract_sync.py
- python3 scripts/verify_builder_public_boundary.py
- python3 scripts/verify_public_surface.py
- python3 scripts/verify_site_surface.py
- python3 scripts/verify_release_surface_sync.py