### PR TITLE
chore: rename top-level manifest to dealyard

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ requires = ["setuptools>=80.0.0", "wheel"]
 build-backend = "setuptools.build_meta"
 
 [project]
-name = "dealwatch"
+name = "dealyard"
 version = "1.0.1"
 description = "DealWatch product backend and worker runtime"
 readme = "README.md"


### PR DESCRIPTION
Sync top-level package/cargo/pyproject `name` field to match the new GitHub repo name **dealyard**.

Part of the 17-repo brand-rename plan (-yard / Open- / *Me families).